### PR TITLE
feat: separate tech blog from main blog as distinct site

### DIFF
--- a/src/components/TechFooter.astro
+++ b/src/components/TechFooter.astro
@@ -10,9 +10,6 @@ const year = new Date().getFullYear()
     </div>
     <nav aria-label="Tech site footer links">
       <ul class="link-list">
-        <li><a href="/tech" class="footer-link">Blog</a></li>
-        <li><a href="/works" class="footer-link">Works</a></li>
-        <li><a href="/resume" class="footer-link">Resume</a></li>
         <li><a href="https://github.com/1lsang" class="footer-link" target="_blank" rel="noopener noreferrer">GitHub</a></li>
         <li><a href="/rss.xml" class="footer-link">RSS</a></li>
       </ul>

--- a/src/components/TechFooter.astro
+++ b/src/components/TechFooter.astro
@@ -1,0 +1,81 @@
+---
+const year = new Date().getFullYear()
+---
+
+<footer class="footer">
+  <div class="container footer-inner">
+    <div class="footer-left">
+      <p class="copyright">© {year} 1lsang</p>
+      <p class="footer-desc">Frontend Engineer · Building interfaces with care.</p>
+    </div>
+    <nav aria-label="Tech site footer links">
+      <ul class="link-list">
+        <li><a href="/tech" class="footer-link">Blog</a></li>
+        <li><a href="/works" class="footer-link">Works</a></li>
+        <li><a href="/resume" class="footer-link">Resume</a></li>
+        <li><a href="https://github.com/1lsang" class="footer-link" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+        <li><a href="/rss.xml" class="footer-link">RSS</a></li>
+      </ul>
+    </nav>
+  </div>
+</footer>
+
+<style>
+  .footer {
+    border-top: 1px solid var(--color-border);
+    padding: var(--spacing-xl) 0;
+    margin-top: var(--spacing-3xl);
+  }
+
+  .footer-inner {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+  }
+
+  .footer-left {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+  }
+
+  .copyright {
+    font-size: 0.875rem;
+    color: var(--color-muted);
+  }
+
+  .footer-desc {
+    font-size: 0.8125rem;
+    color: var(--color-muted);
+    opacity: 0.7;
+  }
+
+  .link-list {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    list-style: none;
+  }
+
+  .footer-link {
+    font-size: 0.875rem;
+    color: var(--color-muted);
+    transition: color var(--transition);
+  }
+
+  .footer-link:hover {
+    color: var(--color-fg);
+  }
+
+  @media (max-width: 640px) {
+    .footer-inner {
+      flex-direction: column;
+    }
+
+    .link-list {
+      flex-wrap: wrap;
+      gap: var(--spacing-sm);
+    }
+  }
+</style>

--- a/src/components/TechHeader.astro
+++ b/src/components/TechHeader.astro
@@ -1,8 +1,8 @@
 ---
 const navLinks = [
-  { href: '/gallery', label: 'Gallery' },
-  { href: '/essay', label: 'Essay' },
-  { href: '/inspirations', label: 'Inspirations' },
+  { href: '/tech', label: 'Blog' },
+  { href: '/works', label: 'Works' },
+  { href: '/resume', label: 'Resume' },
 ]
 
 const pathname = Astro.url.pathname
@@ -10,30 +10,22 @@ const pathname = Astro.url.pathname
 
 <header class="header">
   <div class="container header-inner">
-    <a href="/" class="logo" aria-label="Home">1lsang</a>
-    <nav aria-label="Main navigation">
+    <a href="/tech" class="logo" aria-label="Tech Home">
+      <span class="logo-name">1lsang</span>
+      <span class="logo-badge">dev</span>
+    </a>
+    <nav aria-label="Tech site navigation">
       <ul class="nav-list">
         {navLinks.map(link => (
           <li>
             <a
               href={link.href}
-              class:list={['nav-link', { 'nav-link--active': pathname.startsWith(link.href) }]}
+              class:list={['nav-link', { 'nav-link--active': pathname === link.href || (link.href !== '/tech' && pathname.startsWith(link.href)) || (link.href === '/tech' && (pathname === '/tech' || pathname.startsWith('/tech/'))) }]}
             >
               {link.label}
             </a>
           </li>
         ))}
-        <li>
-          <a
-            href="/tech"
-            class="nav-link nav-link--tech"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Tech blog (opens in new tab)"
-          >
-            Tech ↗
-          </a>
-        </li>
       </ul>
     </nav>
   </div>
@@ -44,7 +36,6 @@ const pathname = Astro.url.pathname
     position: sticky;
     top: 0;
     z-index: 50;
-    background: var(--color-bg);
     border-bottom: 1px solid var(--color-border);
     backdrop-filter: blur(8px);
     background: color-mix(in srgb, var(--color-bg) 90%, transparent);
@@ -58,15 +49,31 @@ const pathname = Astro.url.pathname
   }
 
   .logo {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    text-decoration: none;
+  }
+
+  .logo:hover {
+    opacity: 0.7;
+  }
+
+  .logo-name {
     font-weight: 700;
     font-size: 1rem;
     letter-spacing: -0.03em;
     color: var(--color-fg);
   }
 
-  .logo:hover {
-    color: var(--color-fg);
-    opacity: 0.7;
+  .logo-badge {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    background: var(--color-accent);
+    color: #fff;
+    padding: 0.1em 0.4em;
+    border-radius: var(--radius-sm);
+    letter-spacing: 0.02em;
   }
 
   .nav-list {
@@ -85,16 +92,6 @@ const pathname = Astro.url.pathname
   .nav-link:hover,
   .nav-link--active {
     color: var(--color-fg);
-  }
-
-  .nav-link--tech {
-    color: var(--color-accent);
-    opacity: 0.8;
-  }
-
-  .nav-link--tech:hover {
-    opacity: 1;
-    color: var(--color-accent);
   }
 
   @media (max-width: 640px) {

--- a/src/layouts/TechLayout.astro
+++ b/src/layouts/TechLayout.astro
@@ -1,0 +1,43 @@
+---
+import SEO from '../components/SEO.astro'
+import TechHeader from '../components/TechHeader.astro'
+import TechFooter from '../components/TechFooter.astro'
+import '../styles/global.css'
+
+interface Props {
+  title?: string
+  description?: string
+  image?: string
+  type?: 'website' | 'article'
+}
+
+const { title, description, image, type } = Astro.props
+const umamiId = import.meta.env.PUBLIC_UMAMI_WEBSITE_ID
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="generator" content={Astro.generator} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="preload" as="style" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
+    <SEO title={title} description={description} image={image} type={type} />
+    {umamiId && (
+      <script
+        defer
+        src="https://analytics.umami.is/script.js"
+        data-website-id={umamiId}
+      ></script>
+    )}
+  </head>
+  <body>
+    <TechHeader />
+    <main>
+      <slot />
+    </main>
+    <TechFooter />
+  </body>
+</html>

--- a/src/layouts/TechProseLayout.astro
+++ b/src/layouts/TechProseLayout.astro
@@ -1,0 +1,203 @@
+---
+import TechLayout from './TechLayout.astro'
+
+interface Props {
+  title: string
+  description?: string
+  date?: Date
+  tags?: string[]
+  type?: 'website' | 'article'
+}
+
+const { title, description, date, tags, type = 'article' } = Astro.props
+
+const formattedDate = date
+  ? new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(date)
+  : undefined
+---
+
+<TechLayout title={title} description={description} type={type}>
+  <div class="prose-container container">
+    <article>
+      <header class="article-header">
+        <h1 class="article-title">{title}</h1>
+        {description && <p class="article-desc">{description}</p>}
+        <div class="article-meta">
+          {formattedDate && <time datetime={date?.toISOString()}>{formattedDate}</time>}
+          {tags && tags.length > 0 && (
+            <ul class="tag-list" aria-label="Tags">
+              {tags.map(tag => <li class="tag">{tag}</li>)}
+            </ul>
+          )}
+        </div>
+      </header>
+      <div class="prose">
+        <slot />
+      </div>
+    </article>
+  </div>
+</TechLayout>
+
+<style>
+  .prose-container {
+    padding-top: var(--spacing-3xl);
+    padding-bottom: var(--spacing-3xl);
+  }
+
+  article {
+    max-width: var(--max-w-prose);
+    margin: 0 auto;
+  }
+
+  .article-header {
+    margin-bottom: var(--spacing-2xl);
+    padding-bottom: var(--spacing-xl);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .article-title {
+    font-size: clamp(1.5rem, 4vw, 2.25rem);
+    font-weight: 700;
+    line-height: 1.2;
+    letter-spacing: -0.03em;
+    margin-bottom: var(--spacing-md);
+  }
+
+  .article-desc {
+    font-size: 1.125rem;
+    color: var(--color-muted);
+    line-height: 1.6;
+    margin-bottom: var(--spacing-md);
+  }
+
+  .article-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    flex-wrap: wrap;
+    font-size: 0.875rem;
+    color: var(--color-muted);
+  }
+
+  .tag-list {
+    display: flex;
+    gap: var(--spacing-sm);
+    list-style: none;
+    flex-wrap: wrap;
+  }
+
+  .tag {
+    background: var(--color-code-bg);
+    border: 1px solid var(--color-border);
+    padding: 0.125rem 0.5rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.8125rem;
+  }
+
+  /* Prose content styles */
+  .prose {
+    line-height: 1.8;
+    font-size: 1.0625rem;
+  }
+
+  .prose :global(h2) {
+    font-size: 1.375rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    margin-top: var(--spacing-2xl);
+    margin-bottom: var(--spacing-md);
+  }
+
+  .prose :global(h3) {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin-top: var(--spacing-xl);
+    margin-bottom: var(--spacing-sm);
+  }
+
+  .prose :global(p) {
+    margin-bottom: var(--spacing-lg);
+  }
+
+  .prose :global(ul),
+  .prose :global(ol) {
+    padding-left: var(--spacing-xl);
+    margin-bottom: var(--spacing-lg);
+  }
+
+  .prose :global(li) {
+    margin-bottom: var(--spacing-xs);
+  }
+
+  .prose :global(blockquote) {
+    border-left: 3px solid var(--color-accent);
+    padding-left: var(--spacing-lg);
+    color: var(--color-muted);
+    font-style: italic;
+    margin: var(--spacing-lg) 0;
+  }
+
+  .prose :global(pre) {
+    background: var(--color-code-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--spacing-lg);
+    overflow-x: auto;
+    margin: var(--spacing-lg) 0;
+    font-size: 0.875rem;
+    line-height: 1.7;
+  }
+
+  .prose :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    margin: var(--spacing-lg) 0;
+  }
+
+  .prose :global(th),
+  .prose :global(td) {
+    border: 1px solid var(--color-border);
+    padding: var(--spacing-sm) var(--spacing-md);
+    text-align: left;
+  }
+
+  .prose :global(th) {
+    background: var(--color-code-bg);
+    font-weight: 600;
+  }
+
+  .prose :global(hr) {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: var(--spacing-2xl) 0;
+  }
+
+  .prose :global(iframe) {
+    width: 100%;
+    aspect-ratio: 16/9;
+    border: none;
+    border-radius: var(--radius-md);
+    margin: var(--spacing-lg) 0;
+  }
+
+  .prose :global(a) {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+
+  .prose :global(a:hover) {
+    color: var(--color-accent-hover);
+  }
+
+  .prose :global(img) {
+    border-radius: var(--radius-md);
+    margin: var(--spacing-lg) 0;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,23 +2,15 @@
 import BaseLayout from '../layouts/BaseLayout.astro'
 import { getCollection } from 'astro:content'
 import galleryMeta from '../../content/personal/gallery/metadata.json'
-import projects from '../../content/works/projects.json'
 
 const essays = (await getCollection('essay'))
   .filter(e => !e.data.draft)
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
   .slice(0, 3)
 
-const techPosts = (await getCollection('tech'))
-  .filter(t => !t.data.draft)
-  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
-  .slice(0, 2)
-
 const galleryPreview = [...galleryMeta.items]
   .sort((a, b) => a.order - b.order)
   .slice(0, 4)
-
-const featuredWorks = projects.items.filter(p => p.featured).slice(0, 2)
 
 const formatDate = (date: Date) =>
   new Intl.DateTimeFormat('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' }).format(date)
@@ -78,59 +70,22 @@ const formatDate = (date: Date) =>
     </div>
   </section>
 
-  <!-- Featured Works -->
+  <!-- Tech Blog CTA -->
   <section class="section container">
-    <header class="section-header">
-      <h2 class="section-title">작업물</h2>
-      <a href="/works" class="section-more">전체 보기 →</a>
-    </header>
-    <ul class="works-list">
-      {featuredWorks.map(project => (
-        <li class="work-item">
-          <div class="work-inner">
-            <div class="work-info">
-              <h3 class="work-title">{project.title}</h3>
-              <p class="work-desc">{project.description}</p>
-              <ul class="work-tech">
-                {project.tech.map(t => <li class="tech-tag">{t}</li>)}
-              </ul>
-            </div>
-            <div class="work-links">
-              {project.github && (
-                <a href={project.github} target="_blank" rel="noopener noreferrer" class="work-link">
-                  GitHub
-                </a>
-              )}
-              {project.url && (
-                <a href={project.url} target="_blank" rel="noopener noreferrer" class="work-link">
-                  Live
-                </a>
-              )}
-            </div>
-          </div>
-        </li>
-      ))}
-    </ul>
-  </section>
-
-  <!-- Recent Tech -->
-  <section class="section container">
-    <header class="section-header">
-      <h2 class="section-title">기술 블로그</h2>
-      <a href="/tech" class="section-more">전체 보기 →</a>
-    </header>
-    <ul class="essay-list">
-      {techPosts.map(post => (
-        <li class="essay-item">
-          <a href={`/tech/${post.slug}`} class="essay-link">
-            <span class="essay-title">{post.data.title}</span>
-            <time class="essay-date" datetime={post.data.date.toISOString()}>
-              {formatDate(post.data.date)}
-            </time>
-          </a>
-        </li>
-      ))}
-    </ul>
+    <div class="tech-cta">
+      <div class="tech-cta-text">
+        <h2 class="tech-cta-title">Tech Blog</h2>
+        <p class="tech-cta-desc">개발 관련 글, 프로젝트, 이력서는 별도 사이트에서 확인할 수 있습니다.</p>
+      </div>
+      <a
+        href="/tech"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="tech-cta-link"
+      >
+        방문하기 ↗
+      </a>
+    </div>
   </section>
 </BaseLayout>
 
@@ -268,78 +223,54 @@ const formatDate = (date: Date) =>
     }
   }
 
-  /* Works */
-  .works-list {
-    list-style: none;
+  /* Tech Blog CTA */
+  .tech-cta {
     display: flex;
-    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
     gap: var(--spacing-md);
-  }
-
-  .work-item {
+    padding: var(--spacing-lg);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
-    padding: var(--spacing-lg);
     transition: border-color var(--transition);
   }
 
-  .work-item:hover {
+  .tech-cta:hover {
     border-color: var(--color-accent);
   }
 
-  .work-inner {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: var(--spacing-md);
-  }
-
-  .work-title {
+  .tech-cta-title {
     font-size: 1rem;
     font-weight: 600;
-    margin-bottom: var(--spacing-sm);
+    margin-bottom: var(--spacing-xs);
   }
 
-  .work-desc {
-    font-size: 0.9rem;
+  .tech-cta-desc {
+    font-size: 0.875rem;
     color: var(--color-muted);
-    line-height: 1.6;
-    margin-bottom: var(--spacing-sm);
+    line-height: 1.5;
   }
 
-  .work-tech {
-    display: flex;
-    gap: var(--spacing-xs);
-    flex-wrap: wrap;
-    list-style: none;
-  }
-
-  .tech-tag {
-    font-size: 0.75rem;
-    background: var(--color-code-bg);
-    border: 1px solid var(--color-border);
-    padding: 0.1rem 0.4rem;
+  .tech-cta-link {
+    font-size: 0.875rem;
+    color: var(--color-accent);
+    border: 1px solid var(--color-accent);
+    padding: 0.375rem 0.875rem;
     border-radius: var(--radius-sm);
-    color: var(--color-muted);
-  }
-
-  .work-links {
-    display: flex;
-    gap: var(--spacing-sm);
+    white-space: nowrap;
     flex-shrink: 0;
-  }
-
-  .work-link {
-    font-size: 0.8125rem;
-    color: var(--color-muted);
-    border: 1px solid var(--color-border);
-    padding: 0.25rem 0.625rem;
-    border-radius: var(--radius-sm);
     transition: all var(--transition);
   }
 
-  .work-link:hover {
-    color: var(--color-fg);
-    border-color: var(--color-fg);
+  .tech-cta-link:hover {
+    background: var(--color-accent);
+    color: #fff;
+  }
+
+  @media (max-width: 640px) {
+    .tech-cta {
+      flex-direction: column;
+      align-items: flex-start;
+    }
   }
 </style>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -1,8 +1,8 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro'
+import TechLayout from '../layouts/TechLayout.astro'
 ---
 
-<BaseLayout title="Resume" description="프론트엔드 개발자 이력서.">
+<TechLayout title="Resume" description="Frontend Engineer resume.">
   <div class="container page">
     <div class="resume">
       <!-- Print button -->
@@ -108,7 +108,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
       </section>
     </div>
   </div>
-</BaseLayout>
+</TechLayout>
 
 <style>
   .page {

--- a/src/pages/tech/[slug].astro
+++ b/src/pages/tech/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import ProseLayout from '../../layouts/ProseLayout.astro'
+import TechProseLayout from '../../layouts/TechProseLayout.astro'
 import Giscus from '../../components/Giscus'
 import { getCollection } from 'astro:content'
 
@@ -21,7 +21,7 @@ const giscusRepoId = import.meta.env.PUBLIC_GISCUS_REPO_ID ?? ''
 const giscusCategoryId = import.meta.env.PUBLIC_GISCUS_CATEGORY_ID ?? ''
 ---
 
-<ProseLayout
+<TechProseLayout
   title={post.data.title}
   description={post.data.description}
   date={post.data.date}
@@ -37,4 +37,4 @@ const giscusCategoryId = import.meta.env.PUBLIC_GISCUS_CATEGORY_ID ?? ''
       categoryId={giscusCategoryId}
     />
   )}
-</ProseLayout>
+</TechProseLayout>

--- a/src/pages/tech/index.astro
+++ b/src/pages/tech/index.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro'
+import TechLayout from '../../layouts/TechLayout.astro'
 import { getCollection } from 'astro:content'
 
 const posts = (await getCollection('tech'))
@@ -7,17 +7,17 @@ const posts = (await getCollection('tech'))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
 
 const formatDate = (date: Date) =>
-  new Intl.DateTimeFormat('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' }).format(date)
+  new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'long', day: 'numeric' }).format(date)
 
 // Collect all tags
 const allTags = [...new Set(posts.flatMap(p => p.data.tags))]
 ---
 
-<BaseLayout title="Tech" description="프론트엔드 개발 관련 기술 블로그.">
+<TechLayout title="Tech Blog" description="Frontend development articles and technical writings.">
   <div class="container page">
     <header class="page-header">
       <h1 class="page-title">Tech</h1>
-      <p class="page-desc">총 {posts.length}편의 기술 아티클</p>
+      <p class="page-desc">{posts.length} articles</p>
     </header>
 
     {allTags.length > 0 && (
@@ -51,7 +51,7 @@ const allTags = [...new Set(posts.flatMap(p => p.data.tags))]
       ))}
     </ul>
   </div>
-</BaseLayout>
+</TechLayout>
 
 <style>
   .page {

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -1,16 +1,16 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro'
+import TechLayout from '../../layouts/TechLayout.astro'
 import ProjectCard from '../../components/ProjectCard.astro'
 import projects from '../../../content/works/projects.json'
 
 const sorted = [...projects.items].sort((a, b) => b.year - a.year)
 ---
 
-<BaseLayout title="Works" description="진행한 프로젝트와 오픈소스 기여 내역.">
+<TechLayout title="Works" description="Projects and open source contributions.">
   <div class="container page">
     <header class="page-header">
       <h1 class="page-title">Works</h1>
-      <p class="page-desc">총 {sorted.length}개의 프로젝트</p>
+      <p class="page-desc">{sorted.length} projects</p>
     </header>
 
     <div class="projects-grid">
@@ -27,7 +27,7 @@ const sorted = [...projects.items].sort((a, b) => b.year - a.year)
       ))}
     </div>
   </div>
-</BaseLayout>
+</TechLayout>
 
 <style>
   .page {


### PR DESCRIPTION
## Summary

기술 블로그와 메인 블로그를 완전히 다른 사이트처럼 분리합니다.

### 변경 사항

**새 파일**
- `src/layouts/TechLayout.astro` — 기술 섹션 전용 독립 레이아웃 (TechHeader + TechFooter)
- `src/layouts/TechProseLayout.astro` — 기술 포스트 상세 페이지용 prose 레이아웃
- `src/components/TechHeader.astro` — 기술 섹션 전용 헤더 (Blog / Works / Resume 네비게이션, "1lsang dev" 로고)
- `src/components/TechFooter.astro` — 기술 섹션 전용 푸터

**수정 파일**
- `Header.astro` — Tech/Works/Resume 링크 제거, "Tech ↗" 링크 추가 (새 창으로 열림)
- `pages/index.astro` — Featured Works & Recent Tech 섹션 제거, Tech Blog CTA 카드 추가
- `pages/tech/index.astro` — TechLayout 적용, 영문 날짜 포맷
- `pages/tech/[slug].astro` — TechProseLayout 적용
- `pages/works/index.astro` — TechLayout 적용
- `pages/resume.astro` — TechLayout 적용

### 동작 방식

| 영역 | 레이아웃 | 헤더 |
|---|---|---|
| 메인 블로그 (`/`, `/essay`, `/gallery`, `/inspirations`) | BaseLayout | 메인 헤더 (Tech ↗ 새 창) |
| 기술 블로그 (`/tech`, `/works`, `/resume`) | TechLayout | TechHeader (메인 블로그 링크 없음) |

## Test plan

- [ ] `/` — Tech ↗ 버튼 클릭 시 `/tech`가 새 탭에서 열리는지 확인
- [ ] `/tech` — TechHeader(Blog/Works/Resume)가 노출되고 메인 블로그 링크가 없는지 확인
- [ ] `/works`, `/resume` — TechLayout이 적용되었는지 확인
- [ ] `/essay`, `/gallery` — 기존 메인 헤더가 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)