### PR TITLE
feat: add email subscription to footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,6 +7,41 @@ const socialLinks = [
 ---
 
 <footer class="footer">
+  <!-- Email Subscription -->
+  <div class="subscribe-section container">
+    <div class="subscribe-inner">
+      <div class="subscribe-text">
+        <h2 class="subscribe-title">Stay updated</h2>
+        <p class="subscribe-desc">New essays and occasional notes, delivered to your inbox.</p>
+      </div>
+      <form
+        class="subscribe-form"
+        id="subscribe-form"
+        method="POST"
+        action="/api/subscribe"
+      >
+        <div class="form-row">
+          <label for="subscribe-email" class="sr-only">Email address</label>
+          <input
+            type="email"
+            id="subscribe-email"
+            name="email"
+            class="email-input"
+            placeholder="your@email.com"
+            required
+            autocomplete="email"
+          />
+          <button type="submit" class="subscribe-btn">Subscribe</button>
+        </div>
+        <p class="form-hint">No spam. Unsubscribe anytime.</p>
+      </form>
+      <div class="subscribe-success" id="subscribe-success" hidden>
+        <p class="success-msg">You're subscribed. Thank you!</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer bottom -->
   <div class="container footer-inner">
     <p class="copyright">© {year} 1lsang</p>
     <nav aria-label="Social links">
@@ -29,15 +64,112 @@ const socialLinks = [
 <style>
   .footer {
     border-top: 1px solid var(--color-border);
-    padding: var(--spacing-xl) 0;
     margin-top: var(--spacing-3xl);
   }
 
+  /* Subscribe section */
+  .subscribe-section {
+    padding: var(--spacing-2xl) 0;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .subscribe-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-2xl);
+  }
+
+  .subscribe-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: var(--spacing-xs);
+  }
+
+  .subscribe-desc {
+    font-size: 0.875rem;
+    color: var(--color-muted);
+    line-height: 1.5;
+  }
+
+  .subscribe-form {
+    flex-shrink: 0;
+  }
+
+  .form-row {
+    display: flex;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-xs);
+  }
+
+  .email-input {
+    font-family: inherit;
+    font-size: 0.875rem;
+    color: var(--color-fg);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: 0.5rem 0.75rem;
+    width: 16rem;
+    transition: border-color var(--transition);
+    outline: none;
+  }
+
+  .email-input::placeholder {
+    color: var(--color-muted);
+    opacity: 0.6;
+  }
+
+  .email-input:focus {
+    border-color: var(--color-accent);
+  }
+
+  .subscribe-btn {
+    font-family: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #fff;
+    background: var(--color-accent);
+    border: 1px solid var(--color-accent);
+    border-radius: var(--radius-sm);
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background var(--transition), opacity var(--transition);
+  }
+
+  .subscribe-btn:hover {
+    opacity: 0.85;
+  }
+
+  .subscribe-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .form-hint {
+    font-size: 0.75rem;
+    color: var(--color-muted);
+    opacity: 0.7;
+  }
+
+  .subscribe-success {
+    flex-shrink: 0;
+  }
+
+  .success-msg {
+    font-size: 0.875rem;
+    color: var(--color-accent);
+    font-weight: 500;
+  }
+
+  /* Footer bottom */
   .footer-inner {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: var(--spacing-md);
+    padding: var(--spacing-lg) 0;
   }
 
   .copyright {
@@ -62,6 +194,30 @@ const socialLinks = [
     color: var(--color-fg);
   }
 
+  @media (max-width: 768px) {
+    .subscribe-inner {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--spacing-lg);
+    }
+
+    .subscribe-form {
+      width: 100%;
+    }
+
+    .form-row {
+      flex-direction: column;
+    }
+
+    .email-input {
+      width: 100%;
+    }
+
+    .subscribe-btn {
+      width: 100%;
+    }
+  }
+
   @media (max-width: 640px) {
     .footer-inner {
       flex-direction: column;
@@ -69,3 +225,39 @@ const socialLinks = [
     }
   }
 </style>
+
+<script>
+  const form = document.getElementById('subscribe-form') as HTMLFormElement | null
+  const successEl = document.getElementById('subscribe-success')
+
+  form?.addEventListener('submit', async (e) => {
+    e.preventDefault()
+    const btn = form.querySelector('button[type="submit"]') as HTMLButtonElement
+    const input = form.querySelector('input[type="email"]') as HTMLInputElement
+
+    btn.disabled = true
+    btn.textContent = 'Subscribing...'
+
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: input.value }),
+      })
+
+      if (res.ok) {
+        form.hidden = true
+        if (successEl) successEl.hidden = false
+      } else {
+        const data = await res.json().catch(() => ({}))
+        alert(data.message ?? 'Something went wrong. Please try again.')
+        btn.disabled = false
+        btn.textContent = 'Subscribe'
+      }
+    } catch {
+      alert('Network error. Please try again.')
+      btn.disabled = false
+      btn.textContent = 'Subscribe'
+    }
+  })
+</script>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -69,7 +69,8 @@ const socialLinks = [
 
   /* Subscribe section */
   .subscribe-section {
-    padding: var(--spacing-2xl) 0;
+    padding-top: var(--spacing-2xl);
+    padding-bottom: var(--spacing-2xl);
     border-bottom: 1px solid var(--color-border);
   }
 
@@ -169,7 +170,8 @@ const socialLinks = [
     align-items: center;
     justify-content: space-between;
     gap: var(--spacing-md);
-    padding: var(--spacing-lg) 0;
+    padding-top: var(--spacing-lg);
+    padding-bottom: var(--spacing-lg);
   }
 
   .copyright {

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -1,0 +1,56 @@
+import type { APIRoute } from 'astro'
+
+export const POST: APIRoute = async ({ request }) => {
+  let email: string | undefined
+
+  const contentType = request.headers.get('content-type') ?? ''
+  if (contentType.includes('application/json')) {
+    const body = await request.json().catch(() => ({}))
+    email = body.email
+  } else {
+    const form = await request.formData().catch(() => null)
+    email = form?.get('email')?.toString()
+  }
+
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return new Response(JSON.stringify({ message: 'Valid email address is required.' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // ----------------------------------------------------------------
+  // Integrate your preferred email service here.
+  //
+  // Buttondown:
+  //   const res = await fetch('https://buttondown.email/api/emails/embed-subscribe/<username>', {
+  //     method: 'POST',
+  //     body: new URLSearchParams({ email }),
+  //   })
+  //
+  // ConvertKit:
+  //   const FORM_ID = import.meta.env.CONVERTKIT_FORM_ID
+  //   const API_KEY = import.meta.env.CONVERTKIT_API_KEY
+  //   await fetch(`https://api.convertkit.com/v3/forms/${FORM_ID}/subscribe`, {
+  //     method: 'POST',
+  //     headers: { 'Content-Type': 'application/json' },
+  //     body: JSON.stringify({ api_key: API_KEY, email }),
+  //   })
+  //
+  // Mailchimp, Resend Audiences, or any other provider can be added the same way.
+  // ----------------------------------------------------------------
+
+  // Remove this stub and replace with a real integration above.
+  const subscribeEnabled = import.meta.env.SUBSCRIBE_ENABLED === 'true'
+  if (!subscribeEnabled) {
+    return new Response(JSON.stringify({ message: 'Subscription is not configured yet.' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  return new Response(JSON.stringify({ message: 'Subscribed successfully.' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}


### PR DESCRIPTION
## Summary

메인 블로그와 기술 블로그 Footer에 이메일 구독 폼을 추가합니다.

### 변경 사항

**`src/components/Footer.astro`**
- Footer를 2단 구조로 재설계: 구독 섹션 + 기존 copyright/social 바
- 이메일 입력 + Subscribe 버튼 폼 추가
- 구독 성공 시 폼 숨김 + 성공 메시지 노출
- 에러 처리 (네트워크 오류, API 오류)
- 모바일에서 세로 스택 레이아웃

**`src/pages/api/subscribe.ts`** (새 파일)
- Vercel 서버리스 함수로 `POST /api/subscribe` 엔드포인트 구현
- JSON / FormData 양식 모두 지원
- 이메일 형식 유효성 검사
- Buttondown, ConvertKit, Mailchimp 연동 스텁 코드 포함 (주석 처리)
- `SUBSCRIBE_ENABLED=true` 환경변수 설정 시 활성화

### 서비스 연동 방법

`src/pages/api/subscribe.ts`의 주석 처리된 섹션에서 원하는 서비스 코드를 활성화하고, `.env`에 필요한 환경 변수를 추가하면 됩니다:

```bash
# .env
SUBSCRIBE_ENABLED=true

# ConvertKit 사용 시
CONVERTKIT_FORM_ID=your_form_id
CONVERTKIT_API_KEY=your_api_key
```

## Test plan

- [ ] Footer에 "Stay updated" 구독 섹션이 노출되는지 확인
- [ ] 유효하지 않은 이메일 입력 시 브라우저 유효성 검사 동작 확인
- [ ] `SUBSCRIBE_ENABLED=true` 없이 submit 시 503 응답 처리 확인
- [ ] 성공 응답 시 폼 숨김 + 성공 메시지 노출 확인
- [ ] 모바일(< 768px)에서 세로 스택 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)