### PR TITLE
feat: migrate styling to TailwindCSS utility classes

### DIFF
--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -6,227 +6,63 @@ const socialLinks = [
 ]
 ---
 
-<footer class="footer">
+<footer class="border-t border-border mt-16">
   <!-- Email Subscription -->
-  <div class="subscribe-section container">
-    <div class="subscribe-inner">
-      <div class="subscribe-text">
-        <h2 class="subscribe-title">Stay updated</h2>
-        <p class="subscribe-desc">New essays and occasional notes, delivered to your inbox.</p>
+  <div class="container py-12 border-b border-border">
+    <div class="flex items-center justify-between gap-12 max-md:flex-col max-md:items-start max-md:gap-6">
+      <div>
+        <h2 class="text-base font-semibold mb-1">Stay updated</h2>
+        <p class="text-sm text-muted leading-relaxed">New essays and occasional notes, delivered to your inbox.</p>
       </div>
       <form
-        class="subscribe-form"
+        class="shrink-0 max-md:w-full"
         id="subscribe-form"
         method="POST"
         action="/api/subscribe"
       >
-        <div class="form-row">
+        <div class="flex gap-2 mb-1 max-md:flex-col">
           <label for="subscribe-email" class="sr-only">Email address</label>
           <input
             type="email"
             id="subscribe-email"
             name="email"
-            class="email-input"
+            class="font-[inherit] text-sm text-fg bg-bg border border-border rounded px-3 py-2 w-64 transition-colors outline-none focus:border-accent placeholder:text-muted/60 max-md:w-full"
             placeholder="your@email.com"
             required
             autocomplete="email"
           />
-          <button type="submit" class="subscribe-btn">Subscribe</button>
+          <button
+            type="submit"
+            class="font-[inherit] text-sm font-medium text-white bg-accent border border-accent rounded px-4 py-2 cursor-pointer whitespace-nowrap transition-[background,opacity] hover:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed max-md:w-full"
+          >Subscribe</button>
         </div>
-        <p class="form-hint">No spam. Unsubscribe anytime.</p>
+        <p class="text-xs text-muted opacity-70">No spam. Unsubscribe anytime.</p>
       </form>
-      <div class="subscribe-success" id="subscribe-success" hidden>
-        <p class="success-msg">You're subscribed. Thank you!</p>
+      <div class="shrink-0" id="subscribe-success" hidden>
+        <p class="text-sm text-accent font-medium">You're subscribed. Thank you!</p>
       </div>
     </div>
   </div>
 
   <!-- Footer bottom -->
-  <div class="container footer-inner">
-    <p class="copyright">© {year} 1lsang</p>
+  <div class="container flex items-center justify-between gap-4 py-6 max-sm:flex-col max-sm:items-start">
+    <p class="text-sm text-muted">© {year} 1lsang</p>
     <nav aria-label="Social links">
-      <ul class="social-list">
+      <ul class="flex items-center gap-4 list-none">
         {socialLinks.map(link => (
           <li>
-            <a href={link.href} class="social-link" target="_blank" rel="noopener noreferrer">
+            <a href={link.href} class="text-sm text-muted transition-colors hover:text-fg" target="_blank" rel="noopener noreferrer">
               {link.label}
             </a>
           </li>
         ))}
         <li>
-          <a href="/rss.xml" class="social-link">RSS</a>
+          <a href="/rss.xml" class="text-sm text-muted transition-colors hover:text-fg">RSS</a>
         </li>
       </ul>
     </nav>
   </div>
 </footer>
-
-<style>
-  .footer {
-    border-top: 1px solid var(--color-border);
-    margin-top: var(--spacing-3xl);
-  }
-
-  /* Subscribe section */
-  .subscribe-section {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-2xl);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .subscribe-inner {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-2xl);
-  }
-
-  .subscribe-title {
-    font-size: 1rem;
-    font-weight: 600;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .subscribe-desc {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    line-height: 1.5;
-  }
-
-  .subscribe-form {
-    flex-shrink: 0;
-  }
-
-  .form-row {
-    display: flex;
-    gap: var(--spacing-sm);
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .email-input {
-    font-family: inherit;
-    font-size: 0.875rem;
-    color: var(--color-fg);
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-sm);
-    padding: 0.5rem 0.75rem;
-    width: 16rem;
-    transition: border-color var(--transition);
-    outline: none;
-  }
-
-  .email-input::placeholder {
-    color: var(--color-muted);
-    opacity: 0.6;
-  }
-
-  .email-input:focus {
-    border-color: var(--color-accent);
-  }
-
-  .subscribe-btn {
-    font-family: inherit;
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: #fff;
-    background: var(--color-accent);
-    border: 1px solid var(--color-accent);
-    border-radius: var(--radius-sm);
-    padding: 0.5rem 1rem;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: background var(--transition), opacity var(--transition);
-  }
-
-  .subscribe-btn:hover {
-    opacity: 0.85;
-  }
-
-  .subscribe-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .form-hint {
-    font-size: 0.75rem;
-    color: var(--color-muted);
-    opacity: 0.7;
-  }
-
-  .subscribe-success {
-    flex-shrink: 0;
-  }
-
-  .success-msg {
-    font-size: 0.875rem;
-    color: var(--color-accent);
-    font-weight: 500;
-  }
-
-  /* Footer bottom */
-  .footer-inner {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-md);
-    padding-top: var(--spacing-lg);
-    padding-bottom: var(--spacing-lg);
-  }
-
-  .copyright {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-  }
-
-  .social-list {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-md);
-    list-style: none;
-  }
-
-  .social-link {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    transition: color var(--transition);
-  }
-
-  .social-link:hover {
-    color: var(--color-fg);
-  }
-
-  @media (max-width: 768px) {
-    .subscribe-inner {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--spacing-lg);
-    }
-
-    .subscribe-form {
-      width: 100%;
-    }
-
-    .form-row {
-      flex-direction: column;
-    }
-
-    .email-input {
-      width: 100%;
-    }
-
-    .subscribe-btn {
-      width: 100%;
-    }
-  }
-
-  @media (max-width: 640px) {
-    .footer-inner {
-      flex-direction: column;
-      align-items: flex-start;
-    }
-  }
-</style>
 
 <script>
   const form = document.getElementById('subscribe-form') as HTMLFormElement | null

--- a/apps/web/src/components/Header.astro
+++ b/apps/web/src/components/Header.astro
@@ -16,16 +16,19 @@ const pathname = Astro.url.pathname
 const homeHref = getLocalePath('/', lang)
 ---
 
-<header class="header">
-  <div class="container header-inner">
-    <a href={homeHref} class="logo" aria-label="Home">1lsang</a>
+<header class="sticky top-0 z-50 border-b border-border backdrop-blur-sm bg-bg/90">
+  <div class="container flex items-center justify-between h-14">
+    <a href={homeHref} class="font-bold text-base tracking-[-0.03em] text-fg hover:text-fg hover:opacity-70" aria-label="Home">1lsang</a>
     <nav aria-label="Main navigation">
-      <ul class="nav-list">
+      <ul class="flex items-center gap-6 list-none max-sm:gap-4">
         {navLinks.map(link => (
           <li>
             <a
               href={link.href}
-              class:list={['nav-link', { 'nav-link--active': pathname.startsWith(link.href) }]}
+              class:list={[
+                'text-sm transition-colors',
+                pathname.startsWith(link.href) ? 'text-fg' : 'text-muted hover:text-fg',
+              ]}
             >
               {link.label}
             </a>
@@ -34,7 +37,7 @@ const homeHref = getLocalePath('/', lang)
         <li>
           <a
             href="/tech"
-            class="nav-link nav-link--tech"
+            class="text-sm text-accent opacity-80 hover:opacity-100 hover:text-accent"
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Tech blog (opens in new tab)"
@@ -44,84 +47,9 @@ const homeHref = getLocalePath('/', lang)
         </li>
       </ul>
     </nav>
-    <div class="header-actions">
+    <div class="flex items-center gap-2">
       <ThemeToggle />
       <LanguageSwitcher />
     </div>
   </div>
 </header>
-
-<style>
-  .header {
-    position: sticky;
-    top: 0;
-    z-index: 50;
-    background: var(--color-bg);
-    border-bottom: 1px solid var(--color-border);
-    backdrop-filter: blur(8px);
-    background: color-mix(in srgb, var(--color-bg) 90%, transparent);
-  }
-
-  .header-inner {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: 3.5rem;
-  }
-
-  .logo {
-    font-weight: 700;
-    font-size: 1rem;
-    letter-spacing: -0.03em;
-    color: var(--color-fg);
-  }
-
-  .logo:hover {
-    color: var(--color-fg);
-    opacity: 0.7;
-  }
-
-  .nav-list {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-lg);
-    list-style: none;
-  }
-
-  .nav-link {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    transition: color var(--transition);
-  }
-
-  .nav-link:hover,
-  .nav-link--active {
-    color: var(--color-fg);
-  }
-
-  .nav-link--tech {
-    color: var(--color-accent);
-    opacity: 0.8;
-  }
-
-  .nav-link--tech:hover {
-    opacity: 1;
-    color: var(--color-accent);
-  }
-
-  .header-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-sm);
-  }
-
-  @media (max-width: 640px) {
-    .nav-list {
-      gap: var(--spacing-md);
-    }
-
-    .nav-link {
-      font-size: 0.8125rem;
-    }
-  }
-</style>

--- a/apps/web/src/components/Header.astro
+++ b/apps/web/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import LanguageSwitcher from './LanguageSwitcher.astro'
+import ThemeToggle from './ThemeToggle.astro'
 import { getLangFromUrl, useTranslations, getLocalePath } from '../i18n/utils'
 
 const lang = getLangFromUrl(Astro.url)
@@ -43,7 +44,10 @@ const homeHref = getLocalePath('/', lang)
         </li>
       </ul>
     </nav>
-    <LanguageSwitcher />
+    <div class="header-actions">
+      <ThemeToggle />
+      <LanguageSwitcher />
+    </div>
   </div>
 </header>
 
@@ -103,6 +107,12 @@ const homeHref = getLocalePath('/', lang)
   .nav-link--tech:hover {
     opacity: 1;
     color: var(--color-accent);
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
   }
 
   @media (max-width: 640px) {

--- a/apps/web/src/components/LanguageSwitcher.astro
+++ b/apps/web/src/components/LanguageSwitcher.astro
@@ -5,46 +5,14 @@ import { getLangFromUrl, getAlternatePath } from '../i18n/utils'
 const currentLang = getLangFromUrl(Astro.url)
 ---
 
-<div class="lang-switcher" role="group" aria-label="Language switcher">
+<div class="flex items-center gap-1 border border-border rounded p-0.5" role="group" aria-label="Language switcher">
   {Object.entries(languages).map(([lang]) => (
     lang === currentLang
-      ? <span class="lang-item lang-item--active" aria-current="true">{lang.toUpperCase()}</span>
+      ? <span class="text-xs font-semibold bg-fg text-bg px-1.5 py-0.5 rounded-[2px] tracking-[0.04em] cursor-default" aria-current="true">{lang.toUpperCase()}</span>
       : <a
           href={getAlternatePath(Astro.url, lang as keyof typeof languages)}
-          class="lang-item"
+          class="text-xs font-semibold text-muted px-1.5 py-0.5 rounded-[2px] tracking-[0.04em] transition-all hover:text-fg no-underline"
           hreflang={lang}
         >{lang.toUpperCase()}</a>
   ))}
 </div>
-
-<style>
-  .lang-switcher {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-sm);
-    padding: 0.125rem;
-  }
-
-  .lang-item {
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: var(--color-muted);
-    padding: 0.125rem 0.375rem;
-    border-radius: 2px;
-    transition: all var(--transition);
-    letter-spacing: 0.04em;
-    text-decoration: none;
-  }
-
-  a.lang-item:hover {
-    color: var(--color-fg);
-  }
-
-  .lang-item--active {
-    background: var(--color-fg);
-    color: var(--color-bg);
-    cursor: default;
-  }
-</style>

--- a/apps/web/src/components/ProjectCard.astro
+++ b/apps/web/src/components/ProjectCard.astro
@@ -12,140 +12,34 @@ interface Props {
 const { title, description, tech, thumbnail, github, url, year } = Astro.props
 ---
 
-<article class="project-card">
+<article class="group border border-border rounded-xl overflow-hidden transition-colors hover:border-accent">
   {thumbnail && (
-    <div class="project-thumb">
-      <img src={thumbnail} alt={title} loading="lazy" width="600" height="338" />
+    <div class="w-full aspect-[16/9] bg-code-bg overflow-hidden">
+      <img src={thumbnail} alt={title} loading="lazy" width="600" height="338" class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-[1.02]" />
     </div>
   )}
-  <div class="project-body">
-    <div class="project-meta">
-      <span class="project-year">{year}</span>
+  <div class="p-6 flex flex-col gap-2">
+    <div class="flex items-center gap-2">
+      <span class="text-[0.8125rem] text-muted">{year}</span>
     </div>
-    <h2 class="project-title">{title}</h2>
-    <p class="project-desc">{description}</p>
-    <ul class="project-tech" aria-label="기술 스택">
-      {tech.map(t => <li class="tech-tag">{t}</li>)}
+    <h2 class="text-lg font-semibold tracking-[-0.02em]">{title}</h2>
+    <p class="text-[0.9rem] text-muted leading-relaxed">{description}</p>
+    <ul class="flex gap-1 flex-wrap list-none" aria-label="기술 스택">
+      {tech.map(t => (
+        <li class="text-xs bg-code-bg border border-border px-2 py-[0.15rem] rounded text-muted">{t}</li>
+      ))}
     </ul>
-    <div class="project-links">
+    <div class="flex gap-2 mt-1">
       {github && (
-        <a href={github} class="project-link" target="_blank" rel="noopener noreferrer">
+        <a href={github} class="text-[0.8125rem] px-3 py-[0.35rem] border border-border rounded text-muted transition-all hover:text-fg hover:border-fg" target="_blank" rel="noopener noreferrer">
           GitHub ↗
         </a>
       )}
       {url && (
-        <a href={url} class="project-link project-link--primary" target="_blank" rel="noopener noreferrer">
+        <a href={url} class="text-[0.8125rem] px-3 py-[0.35rem] border border-fg rounded bg-fg text-bg transition-all hover:opacity-80 hover:text-bg" target="_blank" rel="noopener noreferrer">
           Live ↗
         </a>
       )}
     </div>
   </div>
 </article>
-
-<style>
-  .project-card {
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-lg);
-    overflow: hidden;
-    transition: border-color var(--transition);
-  }
-
-  .project-card:hover {
-    border-color: var(--color-accent);
-  }
-
-  .project-thumb {
-    width: 100%;
-    aspect-ratio: 16/9;
-    background: var(--color-code-bg);
-    overflow: hidden;
-  }
-
-  .project-thumb img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    transition: transform 300ms ease;
-  }
-
-  .project-card:hover .project-thumb img {
-    transform: scale(1.02);
-  }
-
-  .project-body {
-    padding: var(--spacing-lg);
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-sm);
-  }
-
-  .project-meta {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-sm);
-  }
-
-  .project-year {
-    font-size: 0.8125rem;
-    color: var(--color-muted);
-  }
-
-  .project-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    letter-spacing: -0.02em;
-  }
-
-  .project-desc {
-    font-size: 0.9rem;
-    color: var(--color-muted);
-    line-height: 1.6;
-  }
-
-  .project-tech {
-    display: flex;
-    gap: var(--spacing-xs);
-    flex-wrap: wrap;
-    list-style: none;
-  }
-
-  .tech-tag {
-    font-size: 0.75rem;
-    background: var(--color-code-bg);
-    border: 1px solid var(--color-border);
-    padding: 0.15rem 0.5rem;
-    border-radius: var(--radius-sm);
-    color: var(--color-muted);
-  }
-
-  .project-links {
-    display: flex;
-    gap: var(--spacing-sm);
-    margin-top: var(--spacing-xs);
-  }
-
-  .project-link {
-    font-size: 0.8125rem;
-    padding: 0.35rem 0.75rem;
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-sm);
-    color: var(--color-muted);
-    transition: all var(--transition);
-  }
-
-  .project-link:hover {
-    color: var(--color-fg);
-    border-color: var(--color-fg);
-  }
-
-  .project-link--primary {
-    background: var(--color-fg);
-    color: var(--color-bg);
-    border-color: var(--color-fg);
-  }
-
-  .project-link--primary:hover {
-    opacity: 0.8;
-    color: var(--color-bg);
-  }
-</style>

--- a/apps/web/src/components/TechFooter.astro
+++ b/apps/web/src/components/TechFooter.astro
@@ -2,77 +2,17 @@
 const year = new Date().getFullYear()
 ---
 
-<footer class="footer">
-  <div class="container footer-inner">
-    <div class="footer-left">
-      <p class="copyright">© {year} 1lsang</p>
-      <p class="footer-desc">Frontend Engineer · Building interfaces with care.</p>
+<footer class="border-t border-border py-8 mt-16">
+  <div class="container flex items-start justify-between gap-4 max-sm:flex-col">
+    <div class="flex flex-col gap-1">
+      <p class="text-sm text-muted">© {year} 1lsang</p>
+      <p class="text-[0.8125rem] text-muted opacity-70">Frontend Engineer · Building interfaces with care.</p>
     </div>
     <nav aria-label="Tech site footer links">
-      <ul class="link-list">
-        <li><a href="https://github.com/1lsang" class="footer-link" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-        <li><a href="/rss.xml" class="footer-link">RSS</a></li>
+      <ul class="flex items-center gap-4 list-none max-sm:flex-wrap max-sm:gap-2">
+        <li><a href="https://github.com/1lsang" class="text-sm text-muted transition-colors hover:text-fg" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+        <li><a href="/rss.xml" class="text-sm text-muted transition-colors hover:text-fg">RSS</a></li>
       </ul>
     </nav>
   </div>
 </footer>
-
-<style>
-  .footer {
-    border-top: 1px solid var(--color-border);
-    padding: var(--spacing-xl) 0;
-    margin-top: var(--spacing-3xl);
-  }
-
-  .footer-inner {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: var(--spacing-md);
-  }
-
-  .footer-left {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
-  }
-
-  .copyright {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-  }
-
-  .footer-desc {
-    font-size: 0.8125rem;
-    color: var(--color-muted);
-    opacity: 0.7;
-  }
-
-  .link-list {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-md);
-    list-style: none;
-  }
-
-  .footer-link {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    transition: color var(--transition);
-  }
-
-  .footer-link:hover {
-    color: var(--color-fg);
-  }
-
-  @media (max-width: 640px) {
-    .footer-inner {
-      flex-direction: column;
-    }
-
-    .link-list {
-      flex-wrap: wrap;
-      gap: var(--spacing-sm);
-    }
-  }
-</style>

--- a/apps/web/src/components/TechHeader.astro
+++ b/apps/web/src/components/TechHeader.astro
@@ -10,19 +10,24 @@ const navLinks = [
 const pathname = Astro.url.pathname
 ---
 
-<header class="header">
-  <div class="container header-inner">
-    <a href="/tech" class="logo" aria-label="Tech Home">
-      <span class="logo-name">1lsang</span>
-      <span class="logo-badge">dev</span>
+<header class="sticky top-0 z-50 border-b border-border backdrop-blur-sm bg-bg/90">
+  <div class="container flex items-center justify-between h-14">
+    <a href="/tech" class="flex items-center gap-1.5 no-underline hover:opacity-70" aria-label="Tech Home">
+      <span class="font-bold text-base tracking-[-0.03em] text-fg">1lsang</span>
+      <span class="text-[0.6875rem] font-semibold bg-accent text-white px-[0.4em] py-[0.1em] rounded tracking-[0.02em]">dev</span>
     </a>
     <nav aria-label="Tech site navigation">
-      <ul class="nav-list">
+      <ul class="flex items-center gap-6 list-none max-sm:gap-4">
         {navLinks.map(link => (
           <li>
             <a
               href={link.href}
-              class:list={['nav-link', { 'nav-link--active': pathname === link.href || (link.href !== '/tech' && pathname.startsWith(link.href)) || (link.href === '/tech' && (pathname === '/tech' || pathname.startsWith('/tech/'))) }]}
+              class:list={[
+                'text-sm transition-colors max-sm:text-[0.8125rem]',
+                (pathname === link.href || (link.href !== '/tech' && pathname.startsWith(link.href)) || (link.href === '/tech' && (pathname === '/tech' || pathname.startsWith('/tech/'))))
+                  ? 'text-fg'
+                  : 'text-muted hover:text-fg',
+              ]}
             >
               {link.label}
             </a>
@@ -33,77 +38,3 @@ const pathname = Astro.url.pathname
     <ThemeToggle />
   </div>
 </header>
-
-<style>
-  .header {
-    position: sticky;
-    top: 0;
-    z-index: 50;
-    border-bottom: 1px solid var(--color-border);
-    backdrop-filter: blur(8px);
-    background: color-mix(in srgb, var(--color-bg) 90%, transparent);
-  }
-
-  .header-inner {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: 3.5rem;
-  }
-
-  .logo {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    text-decoration: none;
-  }
-
-  .logo:hover {
-    opacity: 0.7;
-  }
-
-  .logo-name {
-    font-weight: 700;
-    font-size: 1rem;
-    letter-spacing: -0.03em;
-    color: var(--color-fg);
-  }
-
-  .logo-badge {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    background: var(--color-accent);
-    color: #fff;
-    padding: 0.1em 0.4em;
-    border-radius: var(--radius-sm);
-    letter-spacing: 0.02em;
-  }
-
-  .nav-list {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-lg);
-    list-style: none;
-  }
-
-  .nav-link {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    transition: color var(--transition);
-  }
-
-  .nav-link:hover,
-  .nav-link--active {
-    color: var(--color-fg);
-  }
-
-  @media (max-width: 640px) {
-    .nav-list {
-      gap: var(--spacing-md);
-    }
-
-    .nav-link {
-      font-size: 0.8125rem;
-    }
-  }
-</style>

--- a/apps/web/src/components/TechHeader.astro
+++ b/apps/web/src/components/TechHeader.astro
@@ -1,4 +1,6 @@
 ---
+import ThemeToggle from './ThemeToggle.astro'
+
 const navLinks = [
   { href: '/tech', label: 'Blog' },
   { href: '/works', label: 'Works' },
@@ -28,6 +30,7 @@ const pathname = Astro.url.pathname
         ))}
       </ul>
     </nav>
+    <ThemeToggle />
   </div>
 </header>
 

--- a/apps/web/src/components/ThemeToggle.astro
+++ b/apps/web/src/components/ThemeToggle.astro
@@ -1,57 +1,15 @@
 ---
 ---
 
-<button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">
-  <svg class="icon icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<button id="theme-toggle" class="flex items-center justify-center w-8 h-8 bg-transparent border-0 cursor-pointer text-muted hover:text-fg transition-colors rounded p-0" aria-label="Toggle theme">
+  <svg class="dark:hidden" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <circle cx="12" cy="12" r="4"/>
     <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>
   </svg>
-  <svg class="icon icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <svg class="hidden dark:block" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
   </svg>
 </button>
-
-<style>
-  .theme-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 2rem;
-    height: 2rem;
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--color-muted);
-    transition: color var(--transition);
-    border-radius: var(--radius-sm);
-    padding: 0;
-  }
-
-  .theme-toggle:hover {
-    color: var(--color-fg);
-  }
-
-  .icon-moon {
-    display: none;
-  }
-
-  :global([data-theme="dark"]) .icon-sun {
-    display: none;
-  }
-
-  :global([data-theme="dark"]) .icon-moon {
-    display: block;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    :global(:root:not([data-theme="light"])) .icon-sun {
-      display: none;
-    }
-    :global(:root:not([data-theme="light"])) .icon-moon {
-      display: block;
-    }
-  }
-</style>
 
 <script>
   const toggle = document.getElementById('theme-toggle')!

--- a/apps/web/src/components/ThemeToggle.astro
+++ b/apps/web/src/components/ThemeToggle.astro
@@ -1,0 +1,65 @@
+---
+---
+
+<button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">
+  <svg class="icon icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="4"/>
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>
+  </svg>
+  <svg class="icon icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
+  </svg>
+</button>
+
+<style>
+  .theme-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-muted);
+    transition: color var(--transition);
+    border-radius: var(--radius-sm);
+    padding: 0;
+  }
+
+  .theme-toggle:hover {
+    color: var(--color-fg);
+  }
+
+  .icon-moon {
+    display: none;
+  }
+
+  :global([data-theme="dark"]) .icon-sun {
+    display: none;
+  }
+
+  :global([data-theme="dark"]) .icon-moon {
+    display: block;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :global(:root:not([data-theme="light"])) .icon-sun {
+      display: none;
+    }
+    :global(:root:not([data-theme="light"])) .icon-moon {
+      display: block;
+    }
+  }
+</style>
+
+<script>
+  const toggle = document.getElementById('theme-toggle')!
+  toggle.addEventListener('click', () => {
+    const html = document.documentElement
+    const isDark = html.dataset.theme === 'dark'
+    const next = isDark ? 'light' : 'dark'
+    html.dataset.theme = next
+    localStorage.setItem('theme', next)
+  })
+</script>

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -24,6 +24,10 @@ const lang = getLangFromUrl(Astro.url)
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content={Astro.generator} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <script is:inline>
+      const t = localStorage.getItem('theme') ?? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.dataset.theme = t;
+    </script>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <link rel="preload" as="style" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
     <SEO title={title} description={description} image={image} type={type} />

--- a/apps/web/src/layouts/ProseLayout.astro
+++ b/apps/web/src/layouts/ProseLayout.astro
@@ -25,16 +25,18 @@ const formattedDate = date
 ---
 
 <BaseLayout title={title} description={description} type={type}>
-  <div class="prose-container container">
-    <article>
-      <header class="article-header">
-        <h1 class="article-title">{title}</h1>
-        {description && <p class="article-desc">{description}</p>}
-        <div class="article-meta">
+  <div class="container py-16">
+    <article class="max-w-prose mx-auto">
+      <header class="mb-12 pb-8 border-b border-border">
+        <h1 class="text-[clamp(1.5rem,4vw,2.25rem)] font-bold leading-[1.2] tracking-[-0.03em] mb-4">{title}</h1>
+        {description && <p class="text-lg text-muted leading-relaxed mb-4">{description}</p>}
+        <div class="flex items-center gap-4 flex-wrap text-sm text-muted">
           {formattedDate && <time datetime={date?.toISOString()}>{formattedDate}</time>}
           {tags && tags.length > 0 && (
-            <ul class="tag-list" aria-label="Tags">
-              {tags.map(tag => <li class="tag">{tag}</li>)}
+            <ul class="flex gap-2 list-none flex-wrap" aria-label="Tags">
+              {tags.map(tag => (
+                <li class="bg-code-bg border border-border px-2 py-0.5 rounded text-[0.8125rem]">{tag}</li>
+              ))}
             </ul>
           )}
         </div>
@@ -45,163 +47,3 @@ const formattedDate = date
     </article>
   </div>
 </BaseLayout>
-
-<style>
-  .prose-container {
-    padding-top: var(--spacing-3xl);
-    padding-bottom: var(--spacing-3xl);
-  }
-
-  article {
-    max-width: var(--max-w-prose);
-    margin: 0 auto;
-  }
-
-  .article-header {
-    margin-bottom: var(--spacing-2xl);
-    padding-bottom: var(--spacing-xl);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .article-title {
-    font-size: clamp(1.5rem, 4vw, 2.25rem);
-    font-weight: 700;
-    line-height: 1.2;
-    letter-spacing: -0.03em;
-    margin-bottom: var(--spacing-md);
-  }
-
-  .article-desc {
-    font-size: 1.125rem;
-    color: var(--color-muted);
-    line-height: 1.6;
-    margin-bottom: var(--spacing-md);
-  }
-
-  .article-meta {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-md);
-    flex-wrap: wrap;
-    font-size: 0.875rem;
-    color: var(--color-muted);
-  }
-
-  .tag-list {
-    display: flex;
-    gap: var(--spacing-sm);
-    list-style: none;
-    flex-wrap: wrap;
-  }
-
-  .tag {
-    background: var(--color-code-bg);
-    border: 1px solid var(--color-border);
-    padding: 0.125rem 0.5rem;
-    border-radius: var(--radius-sm);
-    font-size: 0.8125rem;
-  }
-
-  /* Prose content styles */
-  .prose {
-    line-height: 1.8;
-    font-size: 1.0625rem;
-  }
-
-  .prose :global(h2) {
-    font-size: 1.375rem;
-    font-weight: 600;
-    letter-spacing: -0.02em;
-    margin-top: var(--spacing-2xl);
-    margin-bottom: var(--spacing-md);
-  }
-
-  .prose :global(h3) {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-top: var(--spacing-xl);
-    margin-bottom: var(--spacing-sm);
-  }
-
-  .prose :global(p) {
-    margin-bottom: var(--spacing-lg);
-  }
-
-  .prose :global(ul),
-  .prose :global(ol) {
-    padding-left: var(--spacing-xl);
-    margin-bottom: var(--spacing-lg);
-  }
-
-  .prose :global(li) {
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .prose :global(blockquote) {
-    border-left: 3px solid var(--color-accent);
-    padding-left: var(--spacing-lg);
-    color: var(--color-muted);
-    font-style: italic;
-    margin: var(--spacing-lg) 0;
-  }
-
-  .prose :global(pre) {
-    background: var(--color-code-bg);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    padding: var(--spacing-lg);
-    overflow-x: auto;
-    margin: var(--spacing-lg) 0;
-    font-size: 0.875rem;
-    line-height: 1.7;
-  }
-
-  .prose :global(table) {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.9rem;
-    margin: var(--spacing-lg) 0;
-  }
-
-  .prose :global(th),
-  .prose :global(td) {
-    border: 1px solid var(--color-border);
-    padding: var(--spacing-sm) var(--spacing-md);
-    text-align: left;
-  }
-
-  .prose :global(th) {
-    background: var(--color-code-bg);
-    font-weight: 600;
-  }
-
-  .prose :global(hr) {
-    border: none;
-    border-top: 1px solid var(--color-border);
-    margin: var(--spacing-2xl) 0;
-  }
-
-  .prose :global(iframe) {
-    width: 100%;
-    aspect-ratio: 16/9;
-    border: none;
-    border-radius: var(--radius-md);
-    margin: var(--spacing-lg) 0;
-  }
-
-  .prose :global(a) {
-    color: var(--color-accent);
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 2px;
-  }
-
-  .prose :global(a:hover) {
-    color: var(--color-accent-hover);
-  }
-
-  .prose :global(img) {
-    border-radius: var(--radius-md);
-    margin: var(--spacing-lg) 0;
-  }
-</style>

--- a/apps/web/src/layouts/TechLayout.astro
+++ b/apps/web/src/layouts/TechLayout.astro
@@ -22,6 +22,10 @@ const umamiId = import.meta.env.PUBLIC_UMAMI_WEBSITE_ID
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content={Astro.generator} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <script is:inline>
+      const t = localStorage.getItem('theme') ?? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.dataset.theme = t;
+    </script>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <link rel="preload" as="style" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
     <SEO title={title} description={description} image={image} type={type} />

--- a/apps/web/src/layouts/TechProseLayout.astro
+++ b/apps/web/src/layouts/TechProseLayout.astro
@@ -21,16 +21,18 @@ const formattedDate = date
 ---
 
 <TechLayout title={title} description={description} type={type}>
-  <div class="prose-container container">
-    <article>
-      <header class="article-header">
-        <h1 class="article-title">{title}</h1>
-        {description && <p class="article-desc">{description}</p>}
-        <div class="article-meta">
+  <div class="container py-16">
+    <article class="max-w-prose mx-auto">
+      <header class="mb-12 pb-8 border-b border-border">
+        <h1 class="text-[clamp(1.5rem,4vw,2.25rem)] font-bold leading-[1.2] tracking-[-0.03em] mb-4">{title}</h1>
+        {description && <p class="text-lg text-muted leading-relaxed mb-4">{description}</p>}
+        <div class="flex items-center gap-4 flex-wrap text-sm text-muted">
           {formattedDate && <time datetime={date?.toISOString()}>{formattedDate}</time>}
           {tags && tags.length > 0 && (
-            <ul class="tag-list" aria-label="Tags">
-              {tags.map(tag => <li class="tag">{tag}</li>)}
+            <ul class="flex gap-2 list-none flex-wrap" aria-label="Tags">
+              {tags.map(tag => (
+                <li class="bg-code-bg border border-border px-2 py-0.5 rounded text-[0.8125rem]">{tag}</li>
+              ))}
             </ul>
           )}
         </div>
@@ -41,163 +43,3 @@ const formattedDate = date
     </article>
   </div>
 </TechLayout>
-
-<style>
-  .prose-container {
-    padding-top: var(--spacing-3xl);
-    padding-bottom: var(--spacing-3xl);
-  }
-
-  article {
-    max-width: var(--max-w-prose);
-    margin: 0 auto;
-  }
-
-  .article-header {
-    margin-bottom: var(--spacing-2xl);
-    padding-bottom: var(--spacing-xl);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .article-title {
-    font-size: clamp(1.5rem, 4vw, 2.25rem);
-    font-weight: 700;
-    line-height: 1.2;
-    letter-spacing: -0.03em;
-    margin-bottom: var(--spacing-md);
-  }
-
-  .article-desc {
-    font-size: 1.125rem;
-    color: var(--color-muted);
-    line-height: 1.6;
-    margin-bottom: var(--spacing-md);
-  }
-
-  .article-meta {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-md);
-    flex-wrap: wrap;
-    font-size: 0.875rem;
-    color: var(--color-muted);
-  }
-
-  .tag-list {
-    display: flex;
-    gap: var(--spacing-sm);
-    list-style: none;
-    flex-wrap: wrap;
-  }
-
-  .tag {
-    background: var(--color-code-bg);
-    border: 1px solid var(--color-border);
-    padding: 0.125rem 0.5rem;
-    border-radius: var(--radius-sm);
-    font-size: 0.8125rem;
-  }
-
-  /* Prose content styles */
-  .prose {
-    line-height: 1.8;
-    font-size: 1.0625rem;
-  }
-
-  .prose :global(h2) {
-    font-size: 1.375rem;
-    font-weight: 600;
-    letter-spacing: -0.02em;
-    margin-top: var(--spacing-2xl);
-    margin-bottom: var(--spacing-md);
-  }
-
-  .prose :global(h3) {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-top: var(--spacing-xl);
-    margin-bottom: var(--spacing-sm);
-  }
-
-  .prose :global(p) {
-    margin-bottom: var(--spacing-lg);
-  }
-
-  .prose :global(ul),
-  .prose :global(ol) {
-    padding-left: var(--spacing-xl);
-    margin-bottom: var(--spacing-lg);
-  }
-
-  .prose :global(li) {
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .prose :global(blockquote) {
-    border-left: 3px solid var(--color-accent);
-    padding-left: var(--spacing-lg);
-    color: var(--color-muted);
-    font-style: italic;
-    margin: var(--spacing-lg) 0;
-  }
-
-  .prose :global(pre) {
-    background: var(--color-code-bg);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    padding: var(--spacing-lg);
-    overflow-x: auto;
-    margin: var(--spacing-lg) 0;
-    font-size: 0.875rem;
-    line-height: 1.7;
-  }
-
-  .prose :global(table) {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.9rem;
-    margin: var(--spacing-lg) 0;
-  }
-
-  .prose :global(th),
-  .prose :global(td) {
-    border: 1px solid var(--color-border);
-    padding: var(--spacing-sm) var(--spacing-md);
-    text-align: left;
-  }
-
-  .prose :global(th) {
-    background: var(--color-code-bg);
-    font-weight: 600;
-  }
-
-  .prose :global(hr) {
-    border: none;
-    border-top: 1px solid var(--color-border);
-    margin: var(--spacing-2xl) 0;
-  }
-
-  .prose :global(iframe) {
-    width: 100%;
-    aspect-ratio: 16/9;
-    border: none;
-    border-radius: var(--radius-md);
-    margin: var(--spacing-lg) 0;
-  }
-
-  .prose :global(a) {
-    color: var(--color-accent);
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 2px;
-  }
-
-  .prose :global(a:hover) {
-    color: var(--color-accent-hover);
-  }
-
-  .prose :global(img) {
-    border-radius: var(--radius-md);
-    margin: var(--spacing-lg) 0;
-  }
-</style>

--- a/apps/web/src/pages/essay/index.astro
+++ b/apps/web/src/pages/essay/index.astro
@@ -16,23 +16,23 @@ const formatDate = (date: Date) =>
 ---
 
 <BaseLayout title={t('essay.title')} description="Essays on life, thoughts, and reflections.">
-  <div class="container page">
-    <header class="page-header">
-      <h1 class="page-title">{t('essay.title')}</h1>
-      <p class="page-desc">{t('essay.count', { n: essays.length })}</p>
+  <div class="container py-8 pb-16">
+    <header class="mb-8">
+      <h1 class="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] mb-1">{t('essay.title')}</h1>
+      <p class="text-[0.9rem] text-muted">{t('essay.count', { n: essays.length })}</p>
     </header>
 
-    <ul class="essay-list">
+    <ul class="list-none max-w-prose">
       {essays.map(essay => (
-        <li class="essay-item">
-          <a href={getLocalePath(`/essay/${essay.id}`, lang)} class="essay-link">
-            <div class="essay-info">
-              <h2 class="essay-title">{essay.data.title}</h2>
+        <li class="border-b border-border first:border-t first:border-border">
+          <a href={getLocalePath(`/essay/${essay.id}`, lang)} class="group flex items-baseline justify-between gap-6 py-6">
+            <div class="flex-1">
+              <h2 class="text-base font-medium mb-1 transition-colors group-hover:text-accent">{essay.data.title}</h2>
               {essay.data.description && (
-                <p class="essay-desc">{essay.data.description}</p>
+                <p class="text-sm text-muted leading-relaxed">{essay.data.description}</p>
               )}
             </div>
-            <time class="essay-date" datetime={essay.data.date.toISOString()}>
+            <time class="text-[0.8125rem] text-muted whitespace-nowrap shrink-0" datetime={essay.data.date.toISOString()}>
               {formatDate(essay.data.date)}
             </time>
           </a>
@@ -41,76 +41,3 @@ const formatDate = (date: Date) =>
     </ul>
   </div>
 </BaseLayout>
-
-<style>
-  .page {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-3xl);
-  }
-
-  .page-header {
-    margin-bottom: var(--spacing-xl);
-  }
-
-  .page-title {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .page-desc {
-    font-size: 0.9rem;
-    color: var(--color-muted);
-  }
-
-  .essay-list {
-    list-style: none;
-    max-width: var(--max-w-prose);
-  }
-
-  .essay-item {
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .essay-item:first-child {
-    border-top: 1px solid var(--color-border);
-  }
-
-  .essay-link {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--spacing-lg);
-    padding: var(--spacing-lg) 0;
-    transition: color var(--transition);
-  }
-
-  .essay-link:hover .essay-title {
-    color: var(--color-accent);
-  }
-
-  .essay-info {
-    flex: 1;
-  }
-
-  .essay-title {
-    font-size: 1rem;
-    font-weight: 500;
-    margin-bottom: var(--spacing-xs);
-    transition: color var(--transition);
-  }
-
-  .essay-desc {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    line-height: 1.5;
-  }
-
-  .essay-date {
-    font-size: 0.8125rem;
-    color: var(--color-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-</style>

--- a/apps/web/src/pages/gallery.astro
+++ b/apps/web/src/pages/gallery.astro
@@ -17,16 +17,16 @@ const lightboxImages = images.map(item => ({
 ---
 
 <BaseLayout title={t('gallery.title')} description={t('gallery.desc')}>
-  <div class="container page">
-    <header class="page-header">
-      <h1 class="page-title">{t('gallery.title')}</h1>
-      <p class="page-desc">{t('gallery.count', { n: images.length })}</p>
+  <div class="container py-8 pb-16">
+    <header class="mb-8">
+      <h1 class="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] mb-1">{t('gallery.title')}</h1>
+      <p class="text-[0.9rem] text-muted">{t('gallery.count', { n: images.length })}</p>
     </header>
 
-    <div class="gallery-grid" id="gallery-grid">
+    <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2 max-sm:grid-cols-2" id="gallery-grid">
       {images.map((item, index) => (
         <button
-          class="gallery-item"
+          class="group relative aspect-[4/3] overflow-hidden rounded-lg bg-code-bg cursor-pointer border-0 p-0 focus:outline-2 focus:outline-accent focus:outline-offset-2"
           data-index={index}
           aria-label={`사진 보기: ${item.caption}`}
         >
@@ -36,8 +36,11 @@ const lightboxImages = images.map(item => ({
             loading={index < 4 ? 'eager' : 'lazy'}
             width="800"
             height="600"
+            class="w-full h-full object-cover transition-transform duration-400 group-hover:scale-[1.04]"
           />
-          <span class="gallery-caption">{item.caption}</span>
+          <span class="absolute bottom-0 left-0 right-0 px-4 py-2 bg-gradient-to-t from-black/60 to-transparent text-white text-[0.8125rem] opacity-0 transition-opacity group-hover:opacity-100 group-focus:opacity-100">
+            {item.caption}
+          </span>
         </button>
       ))}
     </div>
@@ -48,86 +51,6 @@ const lightboxImages = images.map(item => ({
     />
   </div>
 </BaseLayout>
-
-<style>
-  .page {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-3xl);
-  }
-
-  .page-header {
-    margin-bottom: var(--spacing-xl);
-  }
-
-  .page-title {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .page-desc {
-    font-size: 0.9rem;
-    color: var(--color-muted);
-  }
-
-  .gallery-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: var(--spacing-sm);
-  }
-
-  .gallery-item {
-    position: relative;
-    aspect-ratio: 4/3;
-    overflow: hidden;
-    border-radius: var(--radius-md);
-    background: var(--color-code-bg);
-    cursor: pointer;
-    border: none;
-    padding: 0;
-  }
-
-  .gallery-item img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    transition: transform 400ms ease;
-  }
-
-  .gallery-item:hover img {
-    transform: scale(1.04);
-  }
-
-  .gallery-caption {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    padding: var(--spacing-sm) var(--spacing-md);
-    background: linear-gradient(transparent, rgba(0, 0, 0, 0.6));
-    color: white;
-    font-size: 0.8125rem;
-    opacity: 0;
-    transition: opacity var(--transition);
-  }
-
-  .gallery-item:hover .gallery-caption,
-  .gallery-item:focus .gallery-caption {
-    opacity: 1;
-  }
-
-  .gallery-item:focus {
-    outline: 2px solid var(--color-accent);
-    outline-offset: 2px;
-  }
-
-  @media (max-width: 640px) {
-    .gallery-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-</style>
 
 <script>
   const grid = document.getElementById('gallery-grid')

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -23,26 +23,26 @@ const formatDate = (date: Date) =>
 
 <BaseLayout>
   <!-- Hero -->
-  <section class="hero container">
-    <div class="hero-inner">
-      <h1 class="hero-name">{t('hero.name')}</h1>
-      <p class="hero-tagline">{t('hero.tagline')}</p>
-      <p class="hero-desc" set:html={t('hero.desc').replace('\n', '<br />')} />
+  <section class="container py-16 border-b border-border">
+    <div class="max-w-[36rem]">
+      <h1 class="text-[clamp(2rem,6vw,3.5rem)] font-bold tracking-[-0.04em] mb-4">{t('hero.name')}</h1>
+      <p class="text-lg font-medium mb-4">{t('hero.tagline')}</p>
+      <p class="text-base text-muted leading-[1.8]" set:html={t('hero.desc').replace('\n', '<br />')} />
     </div>
   </section>
 
   <!-- Recent Essays -->
-  <section class="section container">
-    <header class="section-header">
-      <h2 class="section-title">{t('section.recentEssays')}</h2>
-      <a href={getLocalePath('/essay', lang)} class="section-more">{t('section.viewAll')}</a>
+  <section class="container py-12 border-b border-border">
+    <header class="flex items-baseline justify-between mb-6">
+      <h2 class="text-sm font-semibold uppercase tracking-[0.08em] text-muted">{t('section.recentEssays')}</h2>
+      <a href={getLocalePath('/essay', lang)} class="text-sm text-muted transition-colors hover:text-fg">{t('section.viewAll')}</a>
     </header>
-    <ul class="essay-list">
+    <ul class="list-none flex flex-col">
       {essays.map(essay => (
-        <li class="essay-item">
-          <a href={getLocalePath(`/essay/${essay.id}`, lang)} class="essay-link">
-            <span class="essay-title">{essay.data.title}</span>
-            <time class="essay-date" datetime={essay.data.date.toISOString()}>
+        <li class="border-b border-border first:border-t first:border-border">
+          <a href={getLocalePath(`/essay/${essay.id}`, lang)} class="group flex items-baseline justify-between gap-4 py-4">
+            <span class="text-base font-medium transition-colors group-hover:text-accent">{essay.data.title}</span>
+            <time class="text-[0.8125rem] text-muted whitespace-nowrap shrink-0" datetime={essay.data.date.toISOString()}>
               {formatDate(essay.data.date)}
             </time>
           </a>
@@ -52,20 +52,21 @@ const formatDate = (date: Date) =>
   </section>
 
   <!-- Gallery Preview -->
-  <section class="section container">
-    <header class="section-header">
-      <h2 class="section-title">{t('section.gallery')}</h2>
-      <a href={getLocalePath('/gallery', lang)} class="section-more">{t('section.viewAll')}</a>
+  <section class="container py-12 border-b border-border">
+    <header class="flex items-baseline justify-between mb-6">
+      <h2 class="text-sm font-semibold uppercase tracking-[0.08em] text-muted">{t('section.gallery')}</h2>
+      <a href={getLocalePath('/gallery', lang)} class="text-sm text-muted transition-colors hover:text-fg">{t('section.viewAll')}</a>
     </header>
-    <div class="gallery-preview">
+    <div class="grid grid-cols-4 gap-2 max-sm:grid-cols-2">
       {galleryPreview.map(item => (
-        <a href={getLocalePath('/gallery', lang)} class="gallery-thumb" aria-label={item.caption}>
+        <a href={getLocalePath('/gallery', lang)} class="group aspect-[4/3] overflow-hidden rounded-lg bg-code-bg block" aria-label={item.caption}>
           <img
             src={`/gallery/${item.filename}`}
             alt={item.caption}
             loading="lazy"
             width="400"
             height="300"
+            class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
           />
         </a>
       ))}
@@ -73,206 +74,20 @@ const formatDate = (date: Date) =>
   </section>
 
   <!-- Tech Blog CTA -->
-  <section class="section container">
-    <div class="tech-cta">
-      <div class="tech-cta-text">
-        <h2 class="tech-cta-title">{t('section.techBlog')}</h2>
-        <p class="tech-cta-desc">{t('section.techBlogDesc')}</p>
+  <section class="container py-12">
+    <div class="group flex items-center justify-between gap-4 p-6 border border-border rounded-xl transition-colors hover:border-accent max-sm:flex-col max-sm:items-start">
+      <div>
+        <h2 class="text-base font-semibold mb-1">{t('section.techBlog')}</h2>
+        <p class="text-sm text-muted leading-relaxed">{t('section.techBlogDesc')}</p>
       </div>
       <a
         href="/tech"
         target="_blank"
         rel="noopener noreferrer"
-        class="tech-cta-link"
+        class="text-sm text-accent border border-accent px-3.5 py-1.5 rounded whitespace-nowrap shrink-0 transition-all hover:bg-accent hover:text-white"
       >
         {t('section.visitTech')}
       </a>
     </div>
   </section>
 </BaseLayout>
-
-<style>
-  .hero {
-    padding-top: var(--spacing-3xl);
-    padding-bottom: var(--spacing-3xl);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .hero-inner {
-    max-width: 36rem;
-  }
-
-  .hero-name {
-    font-size: clamp(2rem, 6vw, 3.5rem);
-    font-weight: 700;
-    letter-spacing: -0.04em;
-    margin-bottom: var(--spacing-md);
-  }
-
-  .hero-tagline {
-    font-size: 1.125rem;
-    font-weight: 500;
-    margin-bottom: var(--spacing-md);
-  }
-
-  .hero-desc {
-    font-size: 1rem;
-    color: var(--color-muted);
-    line-height: 1.8;
-  }
-
-  .section {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-2xl);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .section-header {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    margin-bottom: var(--spacing-lg);
-  }
-
-  .section-title {
-    font-size: 0.875rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--color-muted);
-  }
-
-  .section-more {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    transition: color var(--transition);
-  }
-
-  .section-more:hover {
-    color: var(--color-fg);
-  }
-
-  /* Essay list */
-  .essay-list {
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-  }
-
-  .essay-item {
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .essay-item:first-child {
-    border-top: 1px solid var(--color-border);
-  }
-
-  .essay-link {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--spacing-md);
-    padding: var(--spacing-md) 0;
-    transition: color var(--transition);
-  }
-
-  .essay-link:hover .essay-title {
-    color: var(--color-accent);
-  }
-
-  .essay-title {
-    font-size: 1rem;
-    font-weight: 500;
-    transition: color var(--transition);
-  }
-
-  .essay-date {
-    font-size: 0.8125rem;
-    color: var(--color-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-
-  /* Gallery preview */
-  .gallery-preview {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: var(--spacing-sm);
-  }
-
-  .gallery-thumb {
-    aspect-ratio: 4/3;
-    overflow: hidden;
-    border-radius: var(--radius-md);
-    background: var(--color-code-bg);
-  }
-
-  .gallery-thumb img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    transition: transform 300ms ease;
-  }
-
-  .gallery-thumb:hover img {
-    transform: scale(1.03);
-  }
-
-  @media (max-width: 640px) {
-    .gallery-preview {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-
-  /* Tech Blog CTA */
-  .tech-cta {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-md);
-    padding: var(--spacing-lg);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-lg);
-    transition: border-color var(--transition);
-  }
-
-  .tech-cta:hover {
-    border-color: var(--color-accent);
-  }
-
-  .tech-cta-title {
-    font-size: 1rem;
-    font-weight: 600;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .tech-cta-desc {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    line-height: 1.5;
-  }
-
-  .tech-cta-link {
-    font-size: 0.875rem;
-    color: var(--color-accent);
-    border: 1px solid var(--color-accent);
-    padding: 0.375rem 0.875rem;
-    border-radius: var(--radius-sm);
-    white-space: nowrap;
-    flex-shrink: 0;
-    transition: all var(--transition);
-  }
-
-  .tech-cta-link:hover {
-    background: var(--color-accent);
-    color: #fff;
-  }
-
-  @media (max-width: 640px) {
-    .tech-cta {
-      flex-direction: column;
-      align-items: flex-start;
-    }
-  }
-</style>

--- a/apps/web/src/pages/inspirations.astro
+++ b/apps/web/src/pages/inspirations.astro
@@ -12,35 +12,12 @@ const t = useTranslations(lang)
   title={t('inspirations.title')}
   description={t('inspirations.desc')}
 >
-  <div class="container page">
-    <header class="page-header">
-      <h1 class="page-title">{t('inspirations.title')}</h1>
-      <p class="page-desc">{t('inspirations.subtitle')}</p>
+  <div class="container py-8 pb-16">
+    <header class="mb-8">
+      <h1 class="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] mb-1">{t('inspirations.title')}</h1>
+      <p class="text-[0.9rem] text-muted">{t('inspirations.subtitle')}</p>
     </header>
 
     <InspirationFilter client:load items={data.items} />
   </div>
 </BaseLayout>
-
-<style>
-  .page {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-3xl);
-  }
-
-  .page-header {
-    margin-bottom: var(--spacing-xl);
-  }
-
-  .page-title {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .page-desc {
-    font-size: 0.9rem;
-    color: var(--color-muted);
-  }
-</style>

--- a/apps/web/src/pages/ko/essay/index.astro
+++ b/apps/web/src/pages/ko/essay/index.astro
@@ -15,23 +15,23 @@ const formatDate = (date: Date) =>
 ---
 
 <BaseLayout title={t('essay.title')} description="일상과 생각, 회고를 담은 에세이.">
-  <div class="container page">
-    <header class="page-header">
-      <h1 class="page-title">{t('essay.title')}</h1>
-      <p class="page-desc">{t('essay.count', { n: essays.length })}</p>
+  <div class="container py-8 pb-16">
+    <header class="mb-8">
+      <h1 class="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] mb-1">{t('essay.title')}</h1>
+      <p class="text-[0.9rem] text-muted">{t('essay.count', { n: essays.length })}</p>
     </header>
 
-    <ul class="essay-list">
+    <ul class="list-none max-w-prose">
       {essays.map(essay => (
-        <li class="essay-item">
-          <a href={getLocalePath(`/essay/${essay.id}`, lang)} class="essay-link">
-            <div class="essay-info">
-              <h2 class="essay-title">{essay.data.title}</h2>
+        <li class="border-b border-border first:border-t first:border-border">
+          <a href={getLocalePath(`/essay/${essay.id}`, lang)} class="group flex items-baseline justify-between gap-6 py-6">
+            <div class="flex-1">
+              <h2 class="text-base font-medium mb-1 transition-colors group-hover:text-accent">{essay.data.title}</h2>
               {essay.data.description && (
-                <p class="essay-desc">{essay.data.description}</p>
+                <p class="text-sm text-muted leading-relaxed">{essay.data.description}</p>
               )}
             </div>
-            <time class="essay-date" datetime={essay.data.date.toISOString()}>
+            <time class="text-[0.8125rem] text-muted whitespace-nowrap shrink-0" datetime={essay.data.date.toISOString()}>
               {formatDate(essay.data.date)}
             </time>
           </a>
@@ -40,76 +40,3 @@ const formatDate = (date: Date) =>
     </ul>
   </div>
 </BaseLayout>
-
-<style>
-  .page {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-3xl);
-  }
-
-  .page-header {
-    margin-bottom: var(--spacing-xl);
-  }
-
-  .page-title {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .page-desc {
-    font-size: 0.9rem;
-    color: var(--color-muted);
-  }
-
-  .essay-list {
-    list-style: none;
-    max-width: var(--max-w-prose);
-  }
-
-  .essay-item {
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .essay-item:first-child {
-    border-top: 1px solid var(--color-border);
-  }
-
-  .essay-link {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--spacing-lg);
-    padding: var(--spacing-lg) 0;
-    transition: color var(--transition);
-  }
-
-  .essay-link:hover .essay-title {
-    color: var(--color-accent);
-  }
-
-  .essay-info {
-    flex: 1;
-  }
-
-  .essay-title {
-    font-size: 1rem;
-    font-weight: 500;
-    margin-bottom: var(--spacing-xs);
-    transition: color var(--transition);
-  }
-
-  .essay-desc {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    line-height: 1.5;
-  }
-
-  .essay-date {
-    font-size: 0.8125rem;
-    color: var(--color-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-</style>

--- a/apps/web/src/pages/ko/gallery.astro
+++ b/apps/web/src/pages/ko/gallery.astro
@@ -17,16 +17,16 @@ const lightboxImages = images.map(item => ({
 ---
 
 <BaseLayout title={t('gallery.title')} description={t('gallery.desc')}>
-  <div class="container page">
-    <header class="page-header">
-      <h1 class="page-title">{t('gallery.title')}</h1>
-      <p class="page-desc">{t('gallery.count', { n: images.length })}</p>
+  <div class="container py-8 pb-16">
+    <header class="mb-8">
+      <h1 class="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] mb-1">{t('gallery.title')}</h1>
+      <p class="text-[0.9rem] text-muted">{t('gallery.count', { n: images.length })}</p>
     </header>
 
-    <div class="gallery-grid" id="gallery-grid">
+    <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2 max-sm:grid-cols-2" id="gallery-grid">
       {images.map((item, index) => (
         <button
-          class="gallery-item"
+          class="group relative aspect-[4/3] overflow-hidden rounded-lg bg-code-bg cursor-pointer border-0 p-0 focus:outline-2 focus:outline-accent focus:outline-offset-2"
           data-index={index}
           aria-label={`사진 보기: ${item.caption}`}
         >
@@ -36,8 +36,11 @@ const lightboxImages = images.map(item => ({
             loading={index < 4 ? 'eager' : 'lazy'}
             width="800"
             height="600"
+            class="w-full h-full object-cover transition-transform duration-400 group-hover:scale-[1.04]"
           />
-          <span class="gallery-caption">{item.caption}</span>
+          <span class="absolute bottom-0 left-0 right-0 px-4 py-2 bg-gradient-to-t from-black/60 to-transparent text-white text-[0.8125rem] opacity-0 transition-opacity group-hover:opacity-100 group-focus:opacity-100">
+            {item.caption}
+          </span>
         </button>
       ))}
     </div>
@@ -45,86 +48,6 @@ const lightboxImages = images.map(item => ({
     <Lightbox client:load images={lightboxImages} />
   </div>
 </BaseLayout>
-
-<style>
-  .page {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-3xl);
-  }
-
-  .page-header {
-    margin-bottom: var(--spacing-xl);
-  }
-
-  .page-title {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .page-desc {
-    font-size: 0.9rem;
-    color: var(--color-muted);
-  }
-
-  .gallery-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: var(--spacing-sm);
-  }
-
-  .gallery-item {
-    position: relative;
-    aspect-ratio: 4/3;
-    overflow: hidden;
-    border-radius: var(--radius-md);
-    background: var(--color-code-bg);
-    cursor: pointer;
-    border: none;
-    padding: 0;
-  }
-
-  .gallery-item img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    transition: transform 400ms ease;
-  }
-
-  .gallery-item:hover img {
-    transform: scale(1.04);
-  }
-
-  .gallery-caption {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    padding: var(--spacing-sm) var(--spacing-md);
-    background: linear-gradient(transparent, rgba(0, 0, 0, 0.6));
-    color: white;
-    font-size: 0.8125rem;
-    opacity: 0;
-    transition: opacity var(--transition);
-  }
-
-  .gallery-item:hover .gallery-caption,
-  .gallery-item:focus .gallery-caption {
-    opacity: 1;
-  }
-
-  .gallery-item:focus {
-    outline: 2px solid var(--color-accent);
-    outline-offset: 2px;
-  }
-
-  @media (max-width: 640px) {
-    .gallery-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-</style>
 
 <script>
   const grid = document.getElementById('gallery-grid')

--- a/apps/web/src/pages/ko/index.astro
+++ b/apps/web/src/pages/ko/index.astro
@@ -22,26 +22,26 @@ const formatDate = (date: Date) =>
 
 <BaseLayout>
   <!-- Hero -->
-  <section class="hero container">
-    <div class="hero-inner">
-      <h1 class="hero-name">{t('hero.name')}</h1>
-      <p class="hero-tagline">{t('hero.tagline')}</p>
-      <p class="hero-desc" set:html={t('hero.desc').replace('\n', '<br />')} />
+  <section class="container py-16 border-b border-border">
+    <div class="max-w-[36rem]">
+      <h1 class="text-[clamp(2rem,6vw,3.5rem)] font-bold tracking-[-0.04em] mb-4">{t('hero.name')}</h1>
+      <p class="text-lg font-medium mb-4">{t('hero.tagline')}</p>
+      <p class="text-base text-muted leading-[1.8]" set:html={t('hero.desc').replace('\n', '<br />')} />
     </div>
   </section>
 
   <!-- Recent Essays -->
-  <section class="section container">
-    <header class="section-header">
-      <h2 class="section-title">{t('section.recentEssays')}</h2>
-      <a href={getLocalePath('/essay', lang)} class="section-more">{t('section.viewAll')}</a>
+  <section class="container py-12 border-b border-border">
+    <header class="flex items-baseline justify-between mb-6">
+      <h2 class="text-sm font-semibold uppercase tracking-[0.08em] text-muted">{t('section.recentEssays')}</h2>
+      <a href={getLocalePath('/essay', lang)} class="text-sm text-muted transition-colors hover:text-fg">{t('section.viewAll')}</a>
     </header>
-    <ul class="essay-list">
+    <ul class="list-none flex flex-col">
       {essays.map(essay => (
-        <li class="essay-item">
-          <a href={getLocalePath(`/essay/${essay.id}`, lang)} class="essay-link">
-            <span class="essay-title">{essay.data.title}</span>
-            <time class="essay-date" datetime={essay.data.date.toISOString()}>
+        <li class="border-b border-border first:border-t first:border-border">
+          <a href={getLocalePath(`/essay/${essay.id}`, lang)} class="group flex items-baseline justify-between gap-4 py-4">
+            <span class="text-base font-medium transition-colors group-hover:text-accent">{essay.data.title}</span>
+            <time class="text-[0.8125rem] text-muted whitespace-nowrap shrink-0" datetime={essay.data.date.toISOString()}>
               {formatDate(essay.data.date)}
             </time>
           </a>
@@ -51,20 +51,21 @@ const formatDate = (date: Date) =>
   </section>
 
   <!-- Gallery Preview -->
-  <section class="section container">
-    <header class="section-header">
-      <h2 class="section-title">{t('section.gallery')}</h2>
-      <a href={getLocalePath('/gallery', lang)} class="section-more">{t('section.viewAll')}</a>
+  <section class="container py-12 border-b border-border">
+    <header class="flex items-baseline justify-between mb-6">
+      <h2 class="text-sm font-semibold uppercase tracking-[0.08em] text-muted">{t('section.gallery')}</h2>
+      <a href={getLocalePath('/gallery', lang)} class="text-sm text-muted transition-colors hover:text-fg">{t('section.viewAll')}</a>
     </header>
-    <div class="gallery-preview">
+    <div class="grid grid-cols-4 gap-2 max-sm:grid-cols-2">
       {galleryPreview.map(item => (
-        <a href={getLocalePath('/gallery', lang)} class="gallery-thumb" aria-label={item.caption}>
+        <a href={getLocalePath('/gallery', lang)} class="group aspect-[4/3] overflow-hidden rounded-lg bg-code-bg block" aria-label={item.caption}>
           <img
             src={`/gallery/${item.filename}`}
             alt={item.caption}
             loading="lazy"
             width="400"
             height="300"
+            class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
           />
         </a>
       ))}
@@ -72,203 +73,20 @@ const formatDate = (date: Date) =>
   </section>
 
   <!-- Tech Blog CTA -->
-  <section class="section container">
-    <div class="tech-cta">
-      <div class="tech-cta-text">
-        <h2 class="tech-cta-title">{t('section.techBlog')}</h2>
-        <p class="tech-cta-desc">{t('section.techBlogDesc')}</p>
+  <section class="container py-12">
+    <div class="flex items-center justify-between gap-4 p-6 border border-border rounded-xl transition-colors hover:border-accent max-sm:flex-col max-sm:items-start">
+      <div>
+        <h2 class="text-base font-semibold mb-1">{t('section.techBlog')}</h2>
+        <p class="text-sm text-muted leading-relaxed">{t('section.techBlogDesc')}</p>
       </div>
       <a
         href="/tech"
         target="_blank"
         rel="noopener noreferrer"
-        class="tech-cta-link"
+        class="text-sm text-accent border border-accent px-3.5 py-1.5 rounded whitespace-nowrap shrink-0 transition-all hover:bg-accent hover:text-white"
       >
         {t('section.visitTech')}
       </a>
     </div>
   </section>
 </BaseLayout>
-
-<style>
-  .hero {
-    padding-top: var(--spacing-3xl);
-    padding-bottom: var(--spacing-3xl);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .hero-inner {
-    max-width: 36rem;
-  }
-
-  .hero-name {
-    font-size: clamp(2rem, 6vw, 3.5rem);
-    font-weight: 700;
-    letter-spacing: -0.04em;
-    margin-bottom: var(--spacing-md);
-  }
-
-  .hero-tagline {
-    font-size: 1.125rem;
-    font-weight: 500;
-    margin-bottom: var(--spacing-md);
-  }
-
-  .hero-desc {
-    font-size: 1rem;
-    color: var(--color-muted);
-    line-height: 1.8;
-  }
-
-  .section {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-2xl);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .section-header {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    margin-bottom: var(--spacing-lg);
-  }
-
-  .section-title {
-    font-size: 0.875rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--color-muted);
-  }
-
-  .section-more {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    transition: color var(--transition);
-  }
-
-  .section-more:hover {
-    color: var(--color-fg);
-  }
-
-  .essay-list {
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-  }
-
-  .essay-item {
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .essay-item:first-child {
-    border-top: 1px solid var(--color-border);
-  }
-
-  .essay-link {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--spacing-md);
-    padding: var(--spacing-md) 0;
-    transition: color var(--transition);
-  }
-
-  .essay-link:hover .essay-title {
-    color: var(--color-accent);
-  }
-
-  .essay-title {
-    font-size: 1rem;
-    font-weight: 500;
-    transition: color var(--transition);
-  }
-
-  .essay-date {
-    font-size: 0.8125rem;
-    color: var(--color-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-
-  .gallery-preview {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: var(--spacing-sm);
-  }
-
-  .gallery-thumb {
-    aspect-ratio: 4/3;
-    overflow: hidden;
-    border-radius: var(--radius-md);
-    background: var(--color-code-bg);
-  }
-
-  .gallery-thumb img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    transition: transform 300ms ease;
-  }
-
-  .gallery-thumb:hover img {
-    transform: scale(1.03);
-  }
-
-  @media (max-width: 640px) {
-    .gallery-preview {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-
-  .tech-cta {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-md);
-    padding: var(--spacing-lg);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-lg);
-    transition: border-color var(--transition);
-  }
-
-  .tech-cta:hover {
-    border-color: var(--color-accent);
-  }
-
-  .tech-cta-title {
-    font-size: 1rem;
-    font-weight: 600;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .tech-cta-desc {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    line-height: 1.5;
-  }
-
-  .tech-cta-link {
-    font-size: 0.875rem;
-    color: var(--color-accent);
-    border: 1px solid var(--color-accent);
-    padding: 0.375rem 0.875rem;
-    border-radius: var(--radius-sm);
-    white-space: nowrap;
-    flex-shrink: 0;
-    transition: all var(--transition);
-  }
-
-  .tech-cta-link:hover {
-    background: var(--color-accent);
-    color: #fff;
-  }
-
-  @media (max-width: 640px) {
-    .tech-cta {
-      flex-direction: column;
-      align-items: flex-start;
-    }
-  }
-</style>

--- a/apps/web/src/pages/ko/inspirations.astro
+++ b/apps/web/src/pages/ko/inspirations.astro
@@ -12,35 +12,12 @@ const t = useTranslations(lang)
   title={t('inspirations.title')}
   description={t('inspirations.desc')}
 >
-  <div class="container page">
-    <header class="page-header">
-      <h1 class="page-title">{t('inspirations.title')}</h1>
-      <p class="page-desc">{t('inspirations.subtitle')}</p>
+  <div class="container py-8 pb-16">
+    <header class="mb-8">
+      <h1 class="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] mb-1">{t('inspirations.title')}</h1>
+      <p class="text-[0.9rem] text-muted">{t('inspirations.subtitle')}</p>
     </header>
 
     <InspirationFilter client:load items={data.items} />
   </div>
 </BaseLayout>
-
-<style>
-  .page {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-3xl);
-  }
-
-  .page-header {
-    margin-bottom: var(--spacing-xl);
-  }
-
-  .page-title {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .page-desc {
-    font-size: 0.9rem;
-    color: var(--color-muted);
-  }
-</style>

--- a/apps/web/src/pages/resume.astro
+++ b/apps/web/src/pages/resume.astro
@@ -3,30 +3,30 @@ import TechLayout from '../layouts/TechLayout.astro'
 ---
 
 <TechLayout title="Resume" description="Frontend Engineer resume.">
-  <div class="container page">
-    <div class="resume">
+  <div class="container py-8 pb-16">
+    <div class="max-w-[48rem] mx-auto">
       <!-- Print button -->
-      <div class="print-bar no-print">
-        <button onclick="window.print()" class="print-btn">인쇄 / PDF 저장</button>
+      <div class="flex justify-end mb-6 no-print">
+        <button onclick="window.print()" class="text-sm font-[inherit] px-4 py-2 border border-border rounded bg-transparent text-muted cursor-pointer transition-all hover:text-fg hover:border-fg">인쇄 / PDF 저장</button>
       </div>
 
       <!-- Header -->
-      <header class="resume-header">
-        <div class="resume-name-block">
-          <h1 class="resume-name">이름 (1lsang)</h1>
-          <p class="resume-role">Frontend Engineer</p>
+      <header class="flex items-start justify-between gap-6 pb-8 border-b-2 border-fg mb-8 max-sm:flex-col">
+        <div>
+          <h1 class="text-[1.75rem] font-bold tracking-[-0.03em] mb-1">이름 (1lsang)</h1>
+          <p class="text-base text-muted">Frontend Engineer</p>
         </div>
-        <ul class="resume-contacts">
-          <li><a href="mailto:hello@1lsang.dev">hello@1lsang.dev</a></li>
-          <li><a href="https://github.com/1lsang" target="_blank" rel="noopener noreferrer">github.com/1lsang</a></li>
-          <li><a href="https://1lsang.dev" target="_blank" rel="noopener noreferrer">1lsang.dev</a></li>
+        <ul class="list-none text-right flex flex-col gap-1 max-sm:text-left">
+          <li><a href="mailto:hello@1lsang.dev" class="text-sm text-muted no-underline transition-colors hover:text-accent">hello@1lsang.dev</a></li>
+          <li><a href="https://github.com/1lsang" target="_blank" rel="noopener noreferrer" class="text-sm text-muted no-underline transition-colors hover:text-accent">github.com/1lsang</a></li>
+          <li><a href="https://1lsang.dev" target="_blank" rel="noopener noreferrer" class="text-sm text-muted no-underline transition-colors hover:text-accent">1lsang.dev</a></li>
         </ul>
       </header>
 
       <!-- Summary -->
-      <section class="resume-section">
-        <h2 class="section-title">Summary</h2>
-        <p class="summary-text">
+      <section class="mb-12">
+        <h2 class="text-xs font-semibold uppercase tracking-[0.1em] text-muted mb-4 pb-1 border-b border-border">Summary</h2>
+        <p class="text-[0.9375rem] leading-[1.7] text-fg">
           사용자 경험을 중심으로 생각하는 프론트엔드 엔지니어입니다.
           React, TypeScript, Astro를 주로 사용하며, 성능과 접근성을 고려한 인터페이스 구축에 관심이 있습니다.
           개인 블로그와 사이드 프로젝트를 통해 지속적으로 탐구하고 기록합니다.
@@ -34,75 +34,75 @@ import TechLayout from '../layouts/TechLayout.astro'
       </section>
 
       <!-- Experience -->
-      <section class="resume-section">
-        <h2 class="section-title">Experience</h2>
-        <div class="experience-list">
-          <article class="experience-item">
-            <div class="experience-header">
+      <section class="mb-12">
+        <h2 class="text-xs font-semibold uppercase tracking-[0.1em] text-muted mb-4 pb-1 border-b border-border">Experience</h2>
+        <div class="flex flex-col gap-6">
+          <article class="break-inside-avoid">
+            <div class="flex justify-between items-start gap-4 mb-2">
               <div>
-                <h3 class="experience-company">Company Name</h3>
-                <p class="experience-role">Frontend Engineer</p>
+                <h3 class="text-base font-semibold mb-[2px]">Company Name</h3>
+                <p class="text-sm text-muted">Frontend Engineer</p>
               </div>
-              <time class="experience-period">2024.01 — 현재</time>
+              <time class="text-[0.8125rem] text-muted whitespace-nowrap shrink-0">2024.01 — 현재</time>
             </div>
-            <ul class="experience-desc">
-              <li>사용자 인터페이스 개발 및 성능 최적화</li>
-              <li>디자인 시스템 구축 및 컴포넌트 라이브러리 관리</li>
-              <li>Core Web Vitals 개선 (LCP 40% 단축)</li>
+            <ul class="pl-6 flex flex-col gap-1">
+              <li class="text-[0.9rem] leading-relaxed">사용자 인터페이스 개발 및 성능 최적화</li>
+              <li class="text-[0.9rem] leading-relaxed">디자인 시스템 구축 및 컴포넌트 라이브러리 관리</li>
+              <li class="text-[0.9rem] leading-relaxed">Core Web Vitals 개선 (LCP 40% 단축)</li>
             </ul>
           </article>
         </div>
       </section>
 
       <!-- Skills -->
-      <section class="resume-section">
-        <h2 class="section-title">Skills</h2>
-        <dl class="skills-grid">
-          <div class="skill-row">
-            <dt class="skill-category">Frontend</dt>
-            <dd class="skill-items">React, TypeScript, Next.js, Astro, Tailwind CSS</dd>
+      <section class="mb-12">
+        <h2 class="text-xs font-semibold uppercase tracking-[0.1em] text-muted mb-4 pb-1 border-b border-border">Skills</h2>
+        <dl class="flex flex-col gap-2">
+          <div class="grid grid-cols-[6rem_1fr] gap-4 items-baseline max-sm:grid-cols-[5rem_1fr]">
+            <dt class="text-[0.8125rem] font-semibold text-muted">Frontend</dt>
+            <dd class="text-[0.9rem] leading-relaxed">React, TypeScript, Next.js, Astro, Tailwind CSS</dd>
           </div>
-          <div class="skill-row">
-            <dt class="skill-category">Tooling</dt>
-            <dd class="skill-items">Vite, Webpack, ESLint, Prettier, Vitest</dd>
+          <div class="grid grid-cols-[6rem_1fr] gap-4 items-baseline max-sm:grid-cols-[5rem_1fr]">
+            <dt class="text-[0.8125rem] font-semibold text-muted">Tooling</dt>
+            <dd class="text-[0.9rem] leading-relaxed">Vite, Webpack, ESLint, Prettier, Vitest</dd>
           </div>
-          <div class="skill-row">
-            <dt class="skill-category">Design</dt>
-            <dd class="skill-items">Figma, 접근성(WCAG), 타이포그래피</dd>
+          <div class="grid grid-cols-[6rem_1fr] gap-4 items-baseline max-sm:grid-cols-[5rem_1fr]">
+            <dt class="text-[0.8125rem] font-semibold text-muted">Design</dt>
+            <dd class="text-[0.9rem] leading-relaxed">Figma, 접근성(WCAG), 타이포그래피</dd>
           </div>
-          <div class="skill-row">
-            <dt class="skill-category">Infra</dt>
-            <dd class="skill-items">Vercel, GitHub Actions, Docker (기초)</dd>
+          <div class="grid grid-cols-[6rem_1fr] gap-4 items-baseline max-sm:grid-cols-[5rem_1fr]">
+            <dt class="text-[0.8125rem] font-semibold text-muted">Infra</dt>
+            <dd class="text-[0.9rem] leading-relaxed">Vercel, GitHub Actions, Docker (기초)</dd>
           </div>
         </dl>
       </section>
 
       <!-- Open Source -->
-      <section class="resume-section">
-        <h2 class="section-title">Open Source</h2>
-        <ul class="project-list">
-          <li class="project-item">
-            <div class="project-header">
-              <a href="https://github.com/1lsang/blog-ui" target="_blank" rel="noopener noreferrer" class="project-name">
+      <section class="mb-12">
+        <h2 class="text-xs font-semibold uppercase tracking-[0.1em] text-muted mb-4 pb-1 border-b border-border">Open Source</h2>
+        <ul class="list-none flex flex-col gap-4">
+          <li class="break-inside-avoid">
+            <div class="flex items-baseline gap-2 mb-1">
+              <a href="https://github.com/1lsang/blog-ui" target="_blank" rel="noopener noreferrer" class="text-[0.9375rem] font-semibold text-accent no-underline hover:underline">
                 blog-ui
               </a>
-              <span class="project-stack">Astro · React · TypeScript</span>
+              <span class="text-[0.8125rem] text-muted">Astro · React · TypeScript</span>
             </div>
-            <p class="project-desc">개인 블로그 & 포트폴리오 엔진. Islands Architecture 기반.</p>
+            <p class="text-sm text-muted leading-relaxed">개인 블로그 & 포트폴리오 엔진. Islands Architecture 기반.</p>
           </li>
         </ul>
       </section>
 
       <!-- Education -->
-      <section class="resume-section">
-        <h2 class="section-title">Education</h2>
-        <article class="experience-item">
-          <div class="experience-header">
+      <section class="mb-12">
+        <h2 class="text-xs font-semibold uppercase tracking-[0.1em] text-muted mb-4 pb-1 border-b border-border">Education</h2>
+        <article class="break-inside-avoid">
+          <div class="flex justify-between items-start gap-4">
             <div>
-              <h3 class="experience-company">대학교</h3>
-              <p class="experience-role">컴퓨터공학 학사</p>
+              <h3 class="text-base font-semibold mb-[2px]">대학교</h3>
+              <p class="text-sm text-muted">컴퓨터공학 학사</p>
             </div>
-            <time class="experience-period">2019 — 2023</time>
+            <time class="text-[0.8125rem] text-muted whitespace-nowrap shrink-0">2019 — 2023</time>
           </div>
         </article>
       </section>
@@ -111,234 +111,9 @@ import TechLayout from '../layouts/TechLayout.astro'
 </TechLayout>
 
 <style>
-  .page {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-3xl);
-  }
-
-  .resume {
-    max-width: 48rem;
-    margin: 0 auto;
-  }
-
-  /* Print bar */
-  .print-bar {
-    display: flex;
-    justify-content: flex-end;
-    margin-bottom: var(--spacing-lg);
-  }
-
-  .print-btn {
-    font-size: 0.875rem;
-    font-family: inherit;
-    padding: 0.5rem 1rem;
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-sm);
-    background: transparent;
-    color: var(--color-muted);
-    cursor: pointer;
-    transition: all var(--transition);
-  }
-
-  .print-btn:hover {
-    color: var(--color-fg);
-    border-color: var(--color-fg);
-  }
-
-  /* Header */
-  .resume-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: var(--spacing-lg);
-    padding-bottom: var(--spacing-xl);
-    border-bottom: 2px solid var(--color-fg);
-    margin-bottom: var(--spacing-xl);
-  }
-
-  .resume-name {
-    font-size: 1.75rem;
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .resume-role {
-    font-size: 1rem;
-    color: var(--color-muted);
-  }
-
-  .resume-contacts {
-    list-style: none;
-    text-align: right;
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
-  }
-
-  .resume-contacts a {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    text-decoration: none;
-    transition: color var(--transition);
-  }
-
-  .resume-contacts a:hover {
-    color: var(--color-accent);
-  }
-
-  /* Section */
-  .resume-section {
-    margin-bottom: var(--spacing-2xl);
-  }
-
-  .section-title {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-muted);
-    margin-bottom: var(--spacing-md);
-    padding-bottom: var(--spacing-xs);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .summary-text {
-    font-size: 0.9375rem;
-    line-height: 1.7;
-    color: var(--color-fg);
-  }
-
-  /* Experience */
-  .experience-list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-lg);
-  }
-
-  .experience-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: var(--spacing-md);
-    margin-bottom: var(--spacing-sm);
-  }
-
-  .experience-company {
-    font-size: 1rem;
-    font-weight: 600;
-    margin-bottom: 2px;
-  }
-
-  .experience-role {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-  }
-
-  .experience-period {
-    font-size: 0.8125rem;
-    color: var(--color-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-
-  .experience-desc {
-    padding-left: var(--spacing-lg);
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
-  }
-
-  .experience-desc li {
-    font-size: 0.9rem;
-    line-height: 1.6;
-    color: var(--color-fg);
-  }
-
-  /* Skills */
-  .skills-grid {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-sm);
-  }
-
-  .skill-row {
-    display: grid;
-    grid-template-columns: 6rem 1fr;
-    gap: var(--spacing-md);
-    align-items: baseline;
-  }
-
-  .skill-category {
-    font-size: 0.8125rem;
-    font-weight: 600;
-    color: var(--color-muted);
-  }
-
-  .skill-items {
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-
-  /* Projects */
-  .project-list {
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-md);
-  }
-
-  .project-header {
-    display: flex;
-    align-items: baseline;
-    gap: var(--spacing-sm);
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .project-name {
-    font-size: 0.9375rem;
-    font-weight: 600;
-    color: var(--color-accent);
-    text-decoration: none;
-  }
-
-  .project-name:hover {
-    text-decoration: underline;
-  }
-
-  .project-stack {
-    font-size: 0.8125rem;
-    color: var(--color-muted);
-  }
-
-  .project-desc {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    line-height: 1.5;
-  }
-
-  @media (max-width: 640px) {
-    .resume-header {
-      flex-direction: column;
-    }
-
-    .resume-contacts {
-      text-align: left;
-    }
-
-    .skill-row {
-      grid-template-columns: 5rem 1fr;
-    }
-  }
-
-  /* Print styles */
   @media print {
     .no-print {
       display: none !important;
-    }
-
-    .page {
-      padding-top: 0;
     }
 
     :global(header),
@@ -351,22 +126,9 @@ import TechLayout from '../layouts/TechLayout.astro'
       color: black;
     }
 
-    .resume {
-      max-width: 100%;
-    }
-
-    .resume-header {
-      border-bottom-color: black;
-    }
-
     a {
       color: black !important;
       text-decoration: none !important;
-    }
-
-    .experience-item,
-    .project-item {
-      page-break-inside: avoid;
     }
   }
 </style>

--- a/apps/web/src/pages/tech/index.astro
+++ b/apps/web/src/pages/tech/index.astro
@@ -14,36 +14,38 @@ const allTags = [...new Set(posts.flatMap(p => p.data.tags))]
 ---
 
 <TechLayout title="Tech Blog" description="Frontend development articles and technical writings.">
-  <div class="container page">
-    <header class="page-header">
-      <h1 class="page-title">Tech</h1>
-      <p class="page-desc">{posts.length} articles</p>
+  <div class="container py-8 pb-16">
+    <header class="mb-8">
+      <h1 class="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] mb-1">Tech</h1>
+      <p class="text-[0.9rem] text-muted">{posts.length} articles</p>
     </header>
 
     {allTags.length > 0 && (
-      <div class="tag-cloud" aria-label="태그 목록">
+      <div class="flex gap-1 flex-wrap mb-8" aria-label="태그 목록">
         {allTags.map(tag => (
-          <span class="tag">{tag}</span>
+          <span class="text-[0.8125rem] bg-code-bg border border-border px-[0.6rem] py-[0.2rem] rounded-full text-muted">{tag}</span>
         ))}
       </div>
     )}
 
-    <ul class="post-list">
+    <ul class="list-none max-w-prose">
       {posts.map(post => (
-        <li class="post-item">
-          <a href={`/tech/${post.id}`} class="post-link">
-            <div class="post-info">
-              <h2 class="post-title">{post.data.title}</h2>
+        <li class="border-b border-border first:border-t first:border-border">
+          <a href={`/tech/${post.id}`} class="group flex items-start justify-between gap-6 py-6">
+            <div class="flex-1">
+              <h2 class="text-base font-medium mb-1 transition-colors group-hover:text-accent">{post.data.title}</h2>
               {post.data.description && (
-                <p class="post-desc">{post.data.description}</p>
+                <p class="text-sm text-muted leading-relaxed mb-2">{post.data.description}</p>
               )}
               {post.data.tags.length > 0 && (
-                <ul class="post-tags" aria-label="태그">
-                  {post.data.tags.map(tag => <li class="post-tag">{tag}</li>)}
+                <ul class="flex gap-1 list-none flex-wrap" aria-label="태그">
+                  {post.data.tags.map(tag => (
+                    <li class="text-xs text-muted bg-code-bg border border-border px-[0.4rem] py-[0.1rem] rounded">{tag}</li>
+                  ))}
                 </ul>
               )}
             </div>
-            <time class="post-date" datetime={post.data.date.toISOString()}>
+            <time class="text-[0.8125rem] text-muted whitespace-nowrap shrink-0 pt-[0.125rem]" datetime={post.data.date.toISOString()}>
               {formatDate(post.data.date)}
             </time>
           </a>
@@ -52,110 +54,3 @@ const allTags = [...new Set(posts.flatMap(p => p.data.tags))]
     </ul>
   </div>
 </TechLayout>
-
-<style>
-  .page {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-3xl);
-  }
-
-  .page-header {
-    margin-bottom: var(--spacing-xl);
-  }
-
-  .page-title {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .page-desc {
-    font-size: 0.9rem;
-    color: var(--color-muted);
-  }
-
-  .tag-cloud {
-    display: flex;
-    gap: var(--spacing-xs);
-    flex-wrap: wrap;
-    margin-bottom: var(--spacing-xl);
-  }
-
-  .tag {
-    font-size: 0.8125rem;
-    background: var(--color-code-bg);
-    border: 1px solid var(--color-border);
-    padding: 0.2rem 0.6rem;
-    border-radius: 2rem;
-    color: var(--color-muted);
-  }
-
-  .post-list {
-    list-style: none;
-    max-width: var(--max-w-prose);
-  }
-
-  .post-item {
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .post-item:first-child {
-    border-top: 1px solid var(--color-border);
-  }
-
-  .post-link {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: var(--spacing-lg);
-    padding: var(--spacing-lg) 0;
-    transition: color var(--transition);
-  }
-
-  .post-link:hover .post-title {
-    color: var(--color-accent);
-  }
-
-  .post-info {
-    flex: 1;
-  }
-
-  .post-title {
-    font-size: 1rem;
-    font-weight: 500;
-    margin-bottom: var(--spacing-xs);
-    transition: color var(--transition);
-  }
-
-  .post-desc {
-    font-size: 0.875rem;
-    color: var(--color-muted);
-    line-height: 1.5;
-    margin-bottom: var(--spacing-sm);
-  }
-
-  .post-tags {
-    display: flex;
-    gap: var(--spacing-xs);
-    list-style: none;
-    flex-wrap: wrap;
-  }
-
-  .post-tag {
-    font-size: 0.75rem;
-    color: var(--color-muted);
-    background: var(--color-code-bg);
-    border: 1px solid var(--color-border);
-    padding: 0.1rem 0.4rem;
-    border-radius: var(--radius-sm);
-  }
-
-  .post-date {
-    font-size: 0.8125rem;
-    color: var(--color-muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-    padding-top: 0.125rem;
-  }
-</style>

--- a/apps/web/src/pages/works/index.astro
+++ b/apps/web/src/pages/works/index.astro
@@ -8,13 +8,13 @@ const sorted = [ohMyClaudecode, personalBlog].sort((a, b) => b.year - a.year)
 ---
 
 <TechLayout title="Works" description="Projects and open source contributions.">
-  <div class="container page">
-    <header class="page-header">
-      <h1 class="page-title">Works</h1>
-      <p class="page-desc">{sorted.length} projects</p>
+  <div class="container py-8 pb-16">
+    <header class="mb-8">
+      <h1 class="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] mb-1">Works</h1>
+      <p class="text-[0.9rem] text-muted">{sorted.length} projects</p>
     </header>
 
-    <div class="projects-grid">
+    <div class="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-6 max-sm:grid-cols-1">
       {sorted.map(project => (
         <ProjectCard
           title={project.title}
@@ -29,38 +29,3 @@ const sorted = [ohMyClaudecode, personalBlog].sort((a, b) => b.year - a.year)
     </div>
   </div>
 </TechLayout>
-
-<style>
-  .page {
-    padding-top: var(--spacing-2xl);
-    padding-bottom: var(--spacing-3xl);
-  }
-
-  .page-header {
-    margin-bottom: var(--spacing-xl);
-  }
-
-  .page-title {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    margin-bottom: var(--spacing-xs);
-  }
-
-  .page-desc {
-    font-size: 0.9rem;
-    color: var(--color-muted);
-  }
-
-  .projects-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-    gap: var(--spacing-lg);
-  }
-
-  @media (max-width: 640px) {
-    .projects-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-</style>

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -1,7 +1,9 @@
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css');
 @import "tailwindcss";
 
-:root {
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
+@theme {
   --font-sans: 'Pretendard Variable', 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
 
@@ -12,27 +14,22 @@
   --color-accent: #2563eb;
   --color-accent-hover: #1d4ed8;
   --color-code-bg: #f8f9fa;
-
-  --spacing-xs: 0.25rem;
-  --spacing-sm: 0.5rem;
-  --spacing-md: 1rem;
-  --spacing-lg: 1.5rem;
-  --spacing-xl: 2rem;
-  --spacing-2xl: 3rem;
-  --spacing-3xl: 4rem;
-
-  --max-w-prose: 65ch;
-  --max-w-page: 80rem;
-
-  --radius-sm: 0.25rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 0.75rem;
-
-  --transition: 150ms ease;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
+@layer base {
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --color-bg: #0a0a0a;
+      --color-fg: #f5f5f5;
+      --color-muted: #9ca3af;
+      --color-border: #1f2937;
+      --color-accent: #3b82f6;
+      --color-accent-hover: #60a5fa;
+      --color-code-bg: #111827;
+    }
+  }
+
+  [data-theme="dark"] {
     --color-bg: #0a0a0a;
     --color-fg: #f5f5f5;
     --color-muted: #9ca3af;
@@ -41,99 +38,186 @@
     --color-accent-hover: #60a5fa;
     --color-code-bg: #111827;
   }
-}
 
-[data-theme="dark"] {
-  --color-bg: #0a0a0a;
-  --color-fg: #f5f5f5;
-  --color-muted: #9ca3af;
-  --color-border: #1f2937;
-  --color-accent: #3b82f6;
-  --color-accent-hover: #60a5fa;
-  --color-code-bg: #111827;
-}
+  *, *::before, *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
 
-*, *::before, *::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+  html {
+    font-family: var(--font-sans);
+    font-size: 16px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    scroll-behavior: smooth;
+  }
 
-html {
-  font-family: var(--font-sans);
-  font-size: 16px;
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  scroll-behavior: smooth;
-}
+  body {
+    background-color: var(--color-bg);
+    color: var(--color-fg);
+    min-height: 100dvh;
+    display: flex;
+    flex-direction: column;
+  }
 
-body {
-  background-color: var(--color-bg);
-  color: var(--color-fg);
-  min-height: 100dvh;
-  display: flex;
-  flex-direction: column;
-}
+  main {
+    flex: 1;
+  }
 
-main {
-  flex: 1;
-}
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
+  a:hover {
+    color: var(--color-accent);
+  }
 
-a:hover {
-  color: var(--color-accent);
-}
+  img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+  }
 
-img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-}
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.875em;
+    background: var(--color-code-bg);
+    padding: 0.125em 0.375em;
+    border-radius: 0.25rem;
+  }
 
-code {
-  font-family: var(--font-mono);
-  font-size: 0.875em;
-  background: var(--color-code-bg);
-  padding: 0.125em 0.375em;
-  border-radius: var(--radius-sm);
-}
+  pre code {
+    background: none;
+    padding: 0;
+  }
 
-pre code {
-  background: none;
-  padding: 0;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  font-weight: 600;
-  line-height: 1.3;
-  letter-spacing: -0.02em;
-}
-
-.container {
-  max-width: var(--max-w-page);
-  margin: 0 auto;
-  padding: 0 var(--spacing-lg);
-}
-
-@media (max-width: 640px) {
-  .container {
-    padding: 0 var(--spacing-md);
+  h1, h2, h3, h4, h5, h6 {
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.02em;
   }
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
+@layer utilities {
+  .container {
+    max-width: 80rem;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  @media (max-width: 640px) {
+    .container {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+  }
+}
+
+@layer components {
+  .prose {
+    line-height: 1.8;
+    font-size: 1.0625rem;
+  }
+
+  .prose h2 {
+    font-size: 1.375rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    margin-top: 3rem;
+    margin-bottom: 1rem;
+  }
+
+  .prose h3 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin-top: 2rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .prose p {
+    margin-bottom: 1.5rem;
+  }
+
+  .prose ul,
+  .prose ol {
+    padding-left: 2rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .prose li {
+    margin-bottom: 0.25rem;
+  }
+
+  .prose blockquote {
+    border-left: 3px solid var(--color-accent);
+    padding-left: 1.5rem;
+    color: var(--color-muted);
+    font-style: italic;
+    margin: 1.5rem 0;
+  }
+
+  .prose pre {
+    background: var(--color-code-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+    font-size: 0.875rem;
+    line-height: 1.7;
+  }
+
+  .prose table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    margin: 1.5rem 0;
+  }
+
+  .prose th,
+  .prose td {
+    border: 1px solid var(--color-border);
+    padding: 0.5rem 1rem;
+    text-align: left;
+  }
+
+  .prose th {
+    background: var(--color-code-bg);
+    font-weight: 600;
+  }
+
+  .prose hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: 3rem 0;
+  }
+
+  .prose iframe {
+    width: 100%;
+    aspect-ratio: 16/9;
+    border: none;
+    border-radius: 0.5rem;
+    margin: 1.5rem 0;
+  }
+
+  .prose a {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+
+  .prose a:hover {
+    color: var(--color-accent-hover);
+  }
+
+  .prose img {
+    border-radius: 0.5rem;
+    margin: 1.5rem 0;
+  }
 }

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -32,7 +32,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme="light"]) {
     --color-bg: #0a0a0a;
     --color-fg: #f5f5f5;
     --color-muted: #9ca3af;
@@ -41,6 +41,16 @@
     --color-accent-hover: #60a5fa;
     --color-code-bg: #111827;
   }
+}
+
+[data-theme="dark"] {
+  --color-bg: #0a0a0a;
+  --color-fg: #f5f5f5;
+  --color-muted: #9ca3af;
+  --color-border: #1f2937;
+  --color-accent: #3b82f6;
+  --color-accent-hover: #60a5fa;
+  --color-code-bg: #111827;
 }
 
 *, *::before, *::after {


### PR DESCRIPTION
## Summary

- `global.css`에 `@custom-variant dark` 설정으로 `data-theme` 속성 기반 다크모드 지원
- 테마 색상/폰트를 `@theme` 토큰으로 등록하여 `bg-bg`, `text-muted`, `border-border` 등 Tailwind 유틸리티로 사용 가능
- prose 콘텐츠 스타일을 `global.css`의 `@layer components`로 이동 (ProseLayout, TechProseLayout 공용)
- 7개 컴포넌트, 2개 레이아웃, 11개 페이지에서 모든 스코프 `<style>` 블록 제거
- `group` / `group-hover:` 유틸리티로 자식 요소 인터랙션 효과 구현

## Changes

- **global.css** — `@custom-variant dark`, `@theme` 토큰, `.container`, `.prose` 컴포넌트 스타일
- **Components** — `Header`, `Footer`, `ThemeToggle`, `LanguageSwitcher`, `TechHeader`, `TechFooter`, `ProjectCard`
- **Layouts** — `ProseLayout`, `TechProseLayout`
- **Pages** — `index`, `essay/index`, `gallery`, `inspirations`, `resume`, `tech/index`, `works/index` (en + ko)

## Test plan

- [x] `pnpm build` 성공 (19개 페이지 빌드, 에러 없음)
- [x] 라이트/다크 모드 전환 확인
- [x] 반응형 레이아웃 (mobile/desktop) 확인
- [x] 한국어/영어 언어 전환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)